### PR TITLE
Vhl swarm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ name = "bex-shell"
 path = "examples/shell/bex-shell.rs"
 
 [[bin]]
+name = "swarm-shell"
+path = "examples/shell/swarm-shell.rs"
+
+[[bin]]
 name = "bdd-solve"
 path = "examples/solve/bdd-solve.rs"
 

--- a/examples/shell/swarm-shell.rs
+++ b/examples/shell/swarm-shell.rs
@@ -1,0 +1,48 @@
+/// This is a (completely useless) shell for interacting with the swarm
+/// while it's running. I wrote it to debug VhlSwarm and figure out how
+/// to send messages to it while it was in a separate thread. (The answer
+/// was to expose q_sender and poll that channel in swarm::run())
+
+use std::io;
+use std::io::Write;
+use std::thread;
+
+use bex::bdd::{NormIteKey, ITE};
+use bex::swarm::SwarmCmd;
+use bex::vhl_swarm::VhlQ;
+use bex::NID;
+
+extern crate bex;
+
+fn readln()->String {
+  let mut buf = String::new();
+  print!("> ");
+  io::stdout().flush()                 .expect("couldn't flush stdout.");
+  io::stdin().read_line(&mut buf)      .expect("failed to read line.");
+  buf}
+
+include!(concat!(env!("OUT_DIR"), "/bex-build-info.rs"));
+fn main() {
+  println!("bex swarm-shell {BEX_VERSION} | compile flags: -O{BEX_OPT_LEVEL} | type 'q' to quit");
+  let mut bdd = bex::bdd::BddBase::new();
+  let to_swarm = bdd.swarm.q_sender();
+
+  // Spawn a new thread for VhlSwarm. `bdd` is moved into the closure.
+  thread::spawn(move || {
+    // TODO: give name to VhlQ<NormIteKey> in bdd modules
+    // !! also maybe swap the argument order for the types?
+    bdd.swarm.run(|_wid, _qid, rmsg|->SwarmCmd<VhlQ<NormIteKey>,()> {
+      if let Some(r) = rmsg {
+        println!("received: {:?}", r);
+        SwarmCmd::Pass }
+      else { SwarmCmd::Pass }})});
+
+  'main: loop {
+    for word in readln().split_whitespace() {
+      match word {
+        "q" => { break 'main}
+        "o" => { to_swarm.send(VhlQ::Job(NormIteKey(ITE {
+          i: NID::var(1),
+          t: NID::var(2),
+          e: NID::var(3)}))).unwrap() }
+        _ => { println!("you typed: {:?}", word) }}}}}

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -98,7 +98,7 @@ impl ITE {
 pub struct BddBase {
   /// allows us to give user-friendly names to specific nodes in the base.
   pub tags: HashMap<String, NID>,
-  swarm: BddSwarm}
+  pub swarm: BddSwarm} // TODO: nopub
 
 impl BddBase {
 

--- a/src/bdd/bdd_swarm.rs
+++ b/src/bdd/bdd_swarm.rs
@@ -1,155 +1,53 @@
-use std::{fmt, sync::mpsc::Sender};
-use std::sync::Arc;
-use crate::{wip, wip::{Dep, ResStep, Answer}};
-use crate::vhl::HiLoPart;
+use crate::{vhl::HiLoPart, wip::{Answer, Dep, ResStep}};
 use crate::nid::NID;
 use crate::bdd::{ITE, NormIteKey, Norm};
-use crate::{swarm, swarm::{WID, QID, Swarm, RMsg}};
-use concurrent_queue::{ConcurrentQueue,PopError};
+use crate::vhl_swarm::{JobKey, VhlJobHandler, VhlSwarm, VhlWorker};
 
-use crate::wip::{WorkState, COUNT_CACHE_HITS, COUNT_CACHE_TESTS};
-
-// ----------------------------------------------------------------
-// BddSwarm Protocol
-// ----------------------------------------------------------------
-
-/// wrapper struct for concurrent queues. This is mostly so we
-/// can implement Default for it.
-#[derive(Debug)]
-struct KQueue<K> { q: ConcurrentQueue<K> }
-impl<K> Default for KQueue<K> {
-  fn default()->Self { KQueue{ q: ConcurrentQueue::unbounded() }}}
-impl<K> KQueue<K> where K:std::fmt::Debug {
-  fn push(&self, k:K) { self.q.push(k).unwrap() }
-  fn pop(&self)->Option<K> {
-    match self.q.pop() {
-      Ok(k) => Some(k),
-      Err(PopError::Empty) => None,
-      Err(PopError::Closed) => panic!("KQueue was closed!") }}}
-
-type IteQueue = KQueue<NormIteKey>;
-
-
-/// Query message for BddSwarm.
-#[derive(Clone)]
- enum Q {
-  /// The main recursive operation: convert ITE triple to a BDD.
-  Ite(NormIteKey),
-  /// Initialize worker with its "hive mind".
-  Init(Arc<WorkState>, Arc<IteQueue>),
-  /// ask for stats about cache
-  Stats }
-
-type R = wip::RMsg;
-
-// Q::Cache() message could potentially be huge to print, so don't.
-impl std::fmt::Debug for Q {
-  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-    match self {
-      Q::Ite(ite) => { write!(f, "Q::Ite({:?})", ite) }
-      Q::Init(_cache, _queue) => { write!(f, "Q::Init(...)") }
-      Q::Stats => { write!(f, "Q::Stats")} } }}
-
-// ----------------------------------------------------------------
+impl JobKey for NormIteKey {}
 
 #[derive(Debug, Default)]
-struct BddWorker {
-  wid:WID,
-  // channel for sending back to the swarm
-  tx:Option<Sender<RMsg<R>>>,
-  next: Option<NormIteKey>,
-  state:Option<Arc<WorkState>>,
-  queue:Option<Arc<IteQueue>> }
+pub struct BddJobHandler {}
 
-impl swarm::Worker<Q,R,NormIteKey> for BddWorker {
-  fn new(wid:WID)->Self { BddWorker{ wid, ..Default::default() }}
-  fn get_wid(&self)->WID { self.wid }
-  fn set_tx(&mut self, tx:&Sender<RMsg<R>>) { self.tx = Some(tx.clone()) }
+impl VhlJobHandler<NormIteKey> for BddJobHandler {
+  type W = VhlWorker<NormIteKey, Self>;
 
-  // TODO: would be nice to never have an un-initialized worker.
-  //       this would require dropping this Q::Init concept.
-  //  (Ideally we would remove the Option<> on .state and .queue)
-  // !! Since the work_loop function is now non-blocking, it will
-  //    try to pop from this queue even before a Q::Init message
-  //    has been sent. So we have to do these dumb existence checks.
-  fn queue_pop(&mut self)->Option<NormIteKey> {
-    if self.next.is_some() { self.next.take() }
-    else if let Some(ref q) = self.queue { q.pop() }
-    else { None }}
-
-  fn queue_push(&mut self, ite:NormIteKey) {
-    if self.next.is_none() { self.next = Some(ite) }
-    else { self.queue.as_ref().unwrap().push(ite) }}
-
-  fn work_item(&mut self, q:NormIteKey) {
-    let res = match self.ite_norm(q) {
-      ResStep::Nid(n) =>
-      self.state.as_ref().unwrap().resolve_nid(&q, n),
+  fn work_job(&mut self, w: &mut Self::W, q:NormIteKey) {
+    let res = match self.ite_norm(w, q) {
+      ResStep::Nid(n) => w.resolve_nid(&q, n),
       ResStep::Wip { v, hi, lo, invert } => {
-        let mut res = None;
-        let state = self.state.as_ref().unwrap();
-        if let Some(answer) = state.add_wip(&q, v, invert) {
-          res = Some(answer) }
-        else { for &(xx, part) in &[(hi,HiLoPart::HiPart), (lo,HiLoPart::LoPart)] {
-          match xx {
-            Norm::Nid(nid) => {
-              let ans = {
-                let s = self.state.as_ref().unwrap();
-                s.resolve_part(&q, part, nid, false)};
-              if let Some(a) = ans { res = Some(a) }},
+        let mut res = w.add_wip(&q, v, invert);
+        if res.is_none() {
+          for &(xx, part) in &[(hi,HiLoPart::HiPart), (lo,HiLoPart::LoPart)] {
+            match xx {
+            Norm::Nid(nid) => { res = w.resolve_part(&q, part, nid, false) },
             Norm::Ite(ite) |
             Norm::Not(ite) => {
-              let (was_new, answer) = {
-                let s = self.state.as_ref().unwrap();
-                s.add_dep(&ite, Dep::new(q, part, xx.is_inv()))};
-              if was_new { self.queue_push(ite) }
-              if answer.is_some() { res = answer } }}}}
+              let (was_new, answer) = w.add_dep(&ite, Dep::new(q, part, xx.is_inv()));
+              if was_new { w.delegate(ite) }
+              res = answer }}}}
         res }};
     if let Some(Answer(nid)) = res {
-      // println!("!! final answer: {:?} !!", nid);
-      let tx = self.tx.as_ref().expect("have answer but no tx!");
-      let qid = {
-        let mut mx = self.state.as_ref().unwrap().qid.lock().unwrap();
-        let q0 = (*mx).expect("no qid found in the mutex!");
-        *mx = None; // unblock the next query!
-        q0};
-      self.send_msg(tx, qid, Some(R::Ret(nid))) }}
+      w.send_answer(&q, nid) }}}
 
-  fn work_step(&mut self, qid:&QID, q:Q)->Option<R> {
-    match q {
-      Q::Init(s, q) => { self.state = Some(s); self.queue=Some(q); None }
-      Q::Ite(ite) => {
-        // println!(">>> new top-level Q: {:?}", q);
-        let s = self.state.as_mut().unwrap();
-        if let Some(cached) = s.get_done(&ite) { return Some(R::Ret(cached)) }
-        // still here, so add new entry:
-        s.cache.entry(ite).or_default();
-        { let mut m = s.qid.lock().unwrap();
-          assert!((*m).is_none(), "already working on a top-level query");
-          *m = Some(*qid); }
-        self.queue_push(ite); None }
-      Q::Stats => {
-        let tests = COUNT_CACHE_TESTS.with(|c| c.replace(0));
-        let hits = COUNT_CACHE_HITS.with(|c| c.replace(0));
-        Some(R::CacheStats{ tests, hits }) } }}}
 
-/// Code run by each thread in the swarm. Isolated as a function without channels for testing.
-impl BddWorker {
+type BddWorker = VhlWorker<NormIteKey, BddJobHandler>;
 
-  fn vhl_norm(&self, ite:NormIteKey)->ResStep {
+impl BddJobHandler {
+
+  fn vhl_norm(&self, w:&BddWorker, ite:NormIteKey)->ResStep {
     let ITE{i:vv,t:hi,e:lo} = ite.0; let v = vv.vid();
-    ResStep::Nid(self.state.as_ref().unwrap().vhl_to_nid(v, hi, lo)) }
+    ResStep::Nid(w.vhl_to_nid(v, hi, lo)) }
 
-  fn ite_norm(&self, ite:NormIteKey)->ResStep {
+  fn ite_norm(&self, w: &BddWorker, ite:NormIteKey)->ResStep {
     let ITE { i, t, e } = ite.0;
     let (vi, vt, ve) = (i.vid(), t.vid(), e.vid());
-    let v = ite.0.top_vid(); let state = self.state.as_ref().unwrap();
-    match state.get_done(&ite) {
+    let v = ite.0.top_vid();
+    match w.get_done(&ite) {
       Some(n) => ResStep::Nid(n),
       None => {
-        let (hi_i, lo_i) = if v == vi {state.tup(i)} else {(i,i)};
-        let (hi_t, lo_t) = if v == vt {state.tup(t)} else {(t,t)};
-        let (hi_e, lo_e) = if v == ve {state.tup(e)} else {(e,e)};
+        let (hi_i, lo_i) = if v == vi {w.tup(i)} else {(i,i)};
+        let (hi_t, lo_t) = if v == vt {w.tup(t)} else {(t,t)};
+        let (hi_e, lo_e) = if v == ve {w.tup(e)} else {(e,e)};
         // now construct and normalize the queries for the hi/lo branches:
         let hi = ITE::norm(hi_i, hi_t, hi_e);
         let lo = ITE::norm(lo_i, lo_t, lo_e);
@@ -160,8 +58,8 @@ impl BddWorker {
             // !! but wait. how is this possible? i.is_const() and v == fake variable "T"?
             Norm::Nid(n) => { ResStep::Nid(n) }
             // otherwise, the normalized triple might already be in cache:
-            Norm::Ite(ite) => self.vhl_norm(ite),
-            Norm::Not(ite) => !self.vhl_norm(ite)}}
+            Norm::Ite(ite) => self.vhl_norm(w, ite),
+            Norm::Not(ite) => !self.vhl_norm(w, ite)}}
         // otherwise at least one side is not a simple nid yet, and we have to defer
         else { ResStep::Wip{ v, hi, lo, invert:false } }}}} }
 
@@ -169,69 +67,17 @@ impl BddWorker {
 // ----------------------------------------------------------------
 /// BddSwarm: a multi-threaded swarm implementation
 // ----------------------------------------------------------------
-#[derive(Debug, Default)]
-pub struct BddSwarm {
-  swarm: Swarm<Q,R,BddWorker,NormIteKey>,
-  /// reference to state shared by all threads.
-  state: Arc<WorkState>,
-  queue: Arc<IteQueue>}
+pub type BddSwarm = VhlSwarm<NormIteKey, BddJobHandler>;
 
-
 impl BddSwarm {
-
-  pub fn new()->Self { let mut me = Self::default(); me.reset(); me }
-
-  pub fn new_with_threads(n:usize)->Self {
-    let mut me = BddSwarm{
-      swarm: Swarm::new_with_threads(n),
-      ..Default::default()};
-    me.reset(); me }
-
-  // reset internal state without the cost of destroying and recreating
-  // all the worker threads.
-  pub fn reset(&mut self) {
-    self.state = Default::default();
-    self.queue = Default::default();
-    self.swarm.send_to_all(&Q::Init(self.state.clone(), self.queue.clone())); }
-
-  pub fn tup(&self, n:NID)->(NID,NID) { self.state.tup(n) }
-
   /// all-purpose if-then-else node constructor. For the swarm implementation,
   /// we push all the normalization and tree traversal work into the threads,
   /// while this function puts all the parts together.
   pub fn ite(&mut self, i:NID, t:NID, e:NID)->NID {
     match ITE::norm(i,t,e) {
       Norm::Nid(n) => n,
-      Norm::Ite(ite) => { self.run_swarm_ite(ite) }
-      Norm::Not(ite) => { !self.run_swarm_ite(ite) }}} }
-
-
-impl BddSwarm {
-
-  fn run_swarm_ite(&mut self, ite:NormIteKey)->NID {
-    let mut result: Option<NID> = None;
-    self.swarm.add_query(Q::Ite(ite));
-    // each response can lead to up to two new ITE queries, and we'll relay those to
-    // other workers too, until we get back enough info to solve the original query.
-    while result.is_none() {
-      let RMsg{wid:_,qid:_,r} = self.swarm.recv().expect("failed to recieve rmsg");
-      if let Some(rmsg) = r { match rmsg {
-        R::Ret(n) => { result = Some(n) }
-        R::CacheStats{ tests:_, hits:_ }
-          => { panic!("got R::CacheStats before sending Q::Stats"); } }}}
-    result.unwrap() }
-
-  pub fn get_stats(&mut self) {
-    self.swarm.send_to_all(&Q::Stats);
-    let (mut tests, mut hits, mut reports) = (0, 0, 0);
-    while reports < self.swarm.num_workers() {
-       let RMsg{wid:_, qid:_, r} = self.swarm.recv().expect("still expecting an Rmsg::CacheStats");
-       if let Some(wip::RMsg::CacheStats{ tests:t, hits: h }) = r { reports += 1; tests+=t; hits += h }
-       else { println!("extraneous rmsg from swarm after Q::Stats: {:?}", r) }}
-    COUNT_CACHE_TESTS.with(|c| *c.borrow_mut() += tests);
-    COUNT_CACHE_HITS.with(|c| *c.borrow_mut() += hits); }
-
-} // end bddswarm
+      Norm::Ite(ite) => { self.run_swarm_job(ite) }
+      Norm::Not(ite) => { !self.run_swarm_job(ite) }}}}
 
 
 #[test] fn test_swarm_cache() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,4 +29,5 @@ pub mod io;
 pub mod anf;
 pub mod swap;
 pub mod swarm;
+pub mod vhl_swarm;
 pub mod naf;

--- a/src/vhl_swarm.rs
+++ b/src/vhl_swarm.rs
@@ -13,7 +13,7 @@ use crate::vid::VID;
 use crate::wip::Answer;
 use crate::NID;
 use crate::{wip, wip::{WorkState, COUNT_CACHE_HITS, COUNT_CACHE_TESTS}};
-use crate::swarm::{RMsg, Swarm, Worker, QID, WID};
+use crate::swarm::{RMsg, Swarm, SwarmCmd, Worker, QID, WID};
 
 type R = wip::RMsg;
 
@@ -154,6 +154,12 @@ impl<J,H> VhlSwarm<J,H> where J:JobKey, H:VhlJobHandler<J,W=VhlWorker<J,H>> {
       swarm: Swarm::new_with_threads(n),
       ..Default::default()};
     me.reset(); me }
+
+  pub fn run<F,V>(&mut self, on_msg:F)->Option<V>
+  where V:fmt::Debug, F:FnMut(WID, &QID, Option<R>)->SwarmCmd<VhlQ<J>, V> {
+    self.swarm.run(on_msg)}
+
+  pub fn q_sender(&self)->Sender<VhlQ<J>> { self.swarm.q_sender() }
 
   // reset internal state without the cost of destroying and recreating
   // all the worker threads.

--- a/src/vhl_swarm.rs
+++ b/src/vhl_swarm.rs
@@ -1,0 +1,185 @@
+//! VHL Swarm
+//! A swarm of workers for WIP VHL Graphs.
+//!
+//! The swarm workers share a common VhlCache and can delegate work to each
+//! other by pushing new jobs onto a shared queue.
+
+use std::sync::mpsc::Sender;
+use std::{fmt, hash::Hash};
+use std::sync::Arc;
+use concurrent_queue::{ConcurrentQueue,PopError};
+use crate::vhl::HiLoPart;
+use crate::vid::VID;
+use crate::wip::Answer;
+use crate::NID;
+use crate::{wip, wip::{WorkState, COUNT_CACHE_HITS, COUNT_CACHE_TESTS}};
+use crate::swarm::{RMsg, Swarm, Worker, QID, WID};
+
+type R = wip::RMsg;
+
+pub trait JobKey : 'static + Copy+Clone+Default+std::fmt::Debug+Eq+Hash+Send+Sync {}
+
+/// wrapper struct for concurrent queue. This exists mostly so we
+/// can implement Default for it. The J parameter indicates a "Job",
+/// which is some kind of message indicating a request to (eventually)
+/// construct a VHL.
+#[derive(Debug)]
+pub struct JobQueue<J> { q: ConcurrentQueue<J> }
+impl<J> Default for JobQueue<J> {
+  fn default()->Self { JobQueue{ q: ConcurrentQueue::unbounded() }}}
+impl<J> JobQueue<J> where J:std::fmt::Debug {
+  pub fn push(&self, job:J) { self.q.push(job).unwrap() }
+  pub fn pop(&self)->Option<J> {
+    match self.q.pop() {
+      Ok(k) => Some(k),
+      Err(PopError::Empty) => None,
+      Err(PopError::Closed) => panic!("JobQueue was closed!") }}}
+
+/// Query messages used by the swarm. There are several general
+/// messages (Init, Stats) that we want for all implementations.
+/// Each implementation has a different kind of "Job" message, though,
+/// so we introduce type parameter J to represent that.
+#[derive(Clone)]
+pub enum VhlQ<J> where J:JobKey {
+  /// The main recursive operation: convert ITE triple to a BDD.
+  Job(J),
+  /// Initialize worker with its "hive mind".
+  Init(Arc<WorkState<J>>, Arc<JobQueue<J>>),
+  /// ask for stats about cache
+  Stats }
+
+// Q::Cache() message could potentially be huge to print, so don't.
+impl<J> fmt::Debug for VhlQ<J> where J:JobKey {
+  fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    match self {
+      VhlQ::Job(j) => { write!(f, "Q::Job({:?})", j) }
+      VhlQ::Init(_cache, _queue) => { write!(f, "Q::Init(...)") }
+      VhlQ::Stats => { write!(f, "Q::Stats")} } }}
+
+
+pub trait VhlJobHandler<J> : Default where J: JobKey {
+  type W : Worker<VhlQ<J>, R, J>;
+  fn work_job(&mut self, w: &mut Self::W, job:J); }
+
+#[derive(Debug, Default)]
+pub struct VhlWorker<J, H> where J:JobKey, H:VhlJobHandler<J,W=Self> {
+  /// worker id
+  wid: WID,
+  /// channel for sending back to the swarm
+  tx:Option<Sender<RMsg<R>>>,
+  /// quick access to the next job in the queue
+  next: Option<J>,
+  /// shared state for all workers
+  state:Option<Arc<WorkState<J>>>,
+  queue:Option<Arc<JobQueue<J>>>,
+  handler: H }
+
+/// These methods expose the WorkState methods on the worker itself.
+impl<J,H> VhlWorker<J, H> where J:JobKey, H:VhlJobHandler<J,W=Self> {
+  pub fn vhl_to_nid(&self, v:VID, hi:NID, lo:NID)->NID {
+    self.state.as_ref().unwrap().vhl_to_nid(v, hi, lo) }
+  pub fn resolve_nid(&mut self, q:&J, n:NID)->Option<Answer<NID>> {
+    self.state.as_ref().unwrap().resolve_nid(q, n) }
+  pub fn add_wip(&mut self, q:&J, vid:VID, invert:bool)->Option<Answer<NID>> {
+    self.state.as_ref().unwrap().add_wip(q, vid, invert) }
+  pub fn resolve_part(&mut self, q:&J, part:HiLoPart, nid:NID, invert:bool)->Option<Answer<NID>> {
+    self.state.as_ref().unwrap().resolve_part(q, part, nid, invert) }
+  pub fn add_dep(&mut self, q:&J, idep:wip::Dep<J>)->(bool, Option<Answer<NID>>) {
+    self.state.as_ref().unwrap().add_dep(q, idep) }
+  pub fn get_done(&self, q:&J)->Option<NID> {
+    self.state.as_ref().unwrap().get_done(q) }
+  pub fn tup(&self, n:NID)->(NID,NID) {
+    self.state.as_ref().unwrap().tup(n) }}
+
+/// this lets a JobHandler send answers and sub-tasks to the swarm.
+impl<J,H> VhlWorker<J,H> where J:JobKey, H:VhlJobHandler<J,W=Self> {
+  pub fn send_answer(&self, _q:&J, nid:NID) {
+    // println!("!! final answer: {:?} !!", nid);
+    let qid = {
+      let mut mx = self.state.as_ref().unwrap().qid.lock().unwrap();
+      let q0 = (*mx).expect("no qid found in the mutex!");
+      *mx = None; // unblock the next query!
+      q0};
+    self.send_msg(qid, Some(R::Ret(nid))) }
+  pub fn delegate(&mut self, job:J) {
+    self.queue_push(job)}
+  pub fn send_msg(&self, qid:QID, r:Option<R>) {
+    self.tx.as_ref().unwrap().send(RMsg{wid:self.wid, qid, r}).unwrap() }}
+
+impl<J,H> Worker<VhlQ<J>, R, J> for VhlWorker<J,H> where J:JobKey, H:VhlJobHandler<J,W=Self> {
+  fn new(wid:WID)->Self { VhlWorker{ wid, ..Default::default() }}
+  fn get_wid(&self)->WID { self.wid }
+  fn set_tx(&mut self, tx:&Sender<RMsg<R>>) { self.tx = Some(tx.clone()) }
+  fn queue_pop(&mut self)->Option<J> {
+    if self.next.is_some() { self.next.take() }
+    else if let Some(ref q) = self.queue { q.pop() }
+    else { None }}
+  fn queue_push(&mut self, job:J) {
+    if self.next.is_none() { self.next = Some(job) }
+    else { self.queue.as_ref().unwrap().push(job) }}
+  fn work_item(&mut self, job:J) {
+    // swap the handler out of self so it can borrow us mutably
+    let mut h = std::mem::take(&mut self.handler);
+    h.work_job(self, job);
+    self.handler = h; }
+  fn work_step(&mut self, _qid:&QID, q:VhlQ<J>)->Option<R> {
+    match q {
+      VhlQ::Init(s, q) => { self.state = Some(s); self.queue=Some(q); None }
+      VhlQ::Job(job) => {
+        let s = self.state.as_mut().unwrap();
+        if let Some(cached) = s.get_done(&job) { return Some(R::Ret(cached)) }
+        s.cache.entry(job).or_default();
+        self.queue_push(job); None }
+      VhlQ::Stats => {
+        let tests = COUNT_CACHE_TESTS.with(|c| c.replace(0));
+        let hits = COUNT_CACHE_HITS.with(|c| c.replace(0));
+        Some(R::CacheStats{ tests, hits }) } }}}
+
+
+#[derive(Debug, Default)]
+pub struct VhlSwarm<J, H> where J:JobKey, H:VhlJobHandler<J,W=VhlWorker<J,H>>{
+  swarm: Swarm<VhlQ<J>, R, VhlWorker<J, H>, J>,
+  state: Arc<WorkState<J>>,
+  queue: Arc<JobQueue<J>>}
+
+impl<J,H> VhlSwarm<J,H> where J:JobKey, H:VhlJobHandler<J,W=VhlWorker<J,H>> {
+
+  pub fn new()->Self { let mut me = Self::default(); me.reset(); me }
+
+  pub fn new_with_threads(n:usize)->Self {
+    let mut me = Self {
+      swarm: Swarm::new_with_threads(n),
+      ..Default::default()};
+    me.reset(); me }
+
+  // reset internal state without the cost of destroying and recreating
+  // all the worker threads.
+  pub fn reset(&mut self) {
+    self.state = Default::default();
+    self.queue = Default::default();
+    self.swarm.send_to_all(&VhlQ::Init(self.state.clone(), self.queue.clone())); }
+
+  pub fn tup(&self, n:NID)->(NID,NID) { self.state.tup(n) }
+
+  pub fn run_swarm_job(&mut self, job:J)->NID {
+    let mut result: Option<NID> = None;
+    self.swarm.add_query(VhlQ::Job(job));
+    // each response can lead to up to two new ITE queries, and we'll relay those to
+    // other workers too, until we get back enough info to solve the original query.
+    while result.is_none() {
+      let RMsg{wid:_,qid:_,r} = self.swarm.recv().expect("failed to recieve rmsg");
+      if let Some(rmsg) = r { match rmsg {
+        R::Ret(n) => { result = Some(n) }
+        R::CacheStats{ tests:_, hits:_ }
+          => { panic!("got R::CacheStats before sending Q::Stats"); } }}}
+    result.unwrap() }
+
+  pub fn get_stats(&mut self) {
+    self.swarm.send_to_all(&VhlQ::Stats);
+    let (mut tests, mut hits, mut reports) = (0, 0, 0);
+    while reports < self.swarm.num_workers() {
+        let RMsg{wid:_, qid:_, r} = self.swarm.recv().expect("still expecting an Rmsg::CacheStats");
+        if let Some(wip::RMsg::CacheStats{ tests:t, hits: h }) = r { reports += 1; tests+=t; hits += h }
+        else { println!("extraneous rmsg from swarm after Q::Stats: {:?}", r) }}
+    COUNT_CACHE_TESTS.with(|c| *c.borrow_mut() += tests);
+    COUNT_CACHE_HITS.with(|c| *c.borrow_mut() += hits); }}


### PR DESCRIPTION
This typechecks but the swarm never returns an answer. 

On the plus side, the bdd-specific code is now separate from the generic VHL-building logic, so it should be much easier to reuse this for ANF/ZDD/etc. going forward.