### PR TITLE
Add table NIDs with named variables and combinadic encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ Bex is a rust crate for working with binary expressions.
 
 ## 0.4.0 (upcoming)
 
-Upcoming changes for 0.4.0 now live in the README section titled \"Changes in main branch (upcoming version)\".
+- **Table NIDs with named variables.** Functions of up to 5 input variables are now stored
+  directly in the NID as a truth table, with the variable set encoded using a combinatorial
+  number system (combinadic). This avoids allocating BDD nodes for small subexpressions.
+  - New `NID::fun_with_vars(&[u32], tbl)` constructor for explicit variable sets.
+  - `NidFun` gains `vars()`, `top_vid()`, `contains_var()`, `var_position()`.
+  - New `src/comb.rs` module: combinadic encode/decode for variable subsets of up to 110 variables.
+  - New `src/tbl.rs` module: truth table alignment, expansion, and bitwise operations
+    (`table_and`, `table_xor`, `table_or`, `table_ite`) with zero-allocation fast path.
+  - `BddBase::ite()` now automatically resolves small operations via truth tables before
+    entering the BDD swarm (zero overhead on large problems, avoids node allocation for small ones).
+  - `VhlBase::tup()` decomposes table NIDs into hi/lo branches transparently.
+  - Display format `T{x3,x7:1110}` for table NIDs with non-default variable sets;
+    `FromStr` round-trips the new format.
+
+Older upcoming changes for 0.4.0 live in the README section titled \"Changes in main branch (upcoming version)\".
 
 ### Performance
 - ~22% speedup on BDD factoring benchmark (`small`: factor 210 into 8x16-bit integers)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ and the smaller tests in [src/solve.rs](src/solve.rs)
 
 ## Changes in main branch (upcoming version)
 
+- **Table NIDs with named variables:** truth tables of up to 5 inputs are now stored directly in the NID, with the variable set encoded via a combinadic index. `BddBase::ite()` automatically uses truth table operations for small subexpressions before entering the BDD swarm. New modules: `comb` (combinadic encoding), `tbl` (table alignment and operations). New display format: `T{x3,x7:1110}`.
 - add C ffi for use with https://github.com/SSoelvsten/bdd-benchmark (bex adapter is at https://github.com/tangentforks/bdd-benchmark for now)
 - add `ite` to the Base trait
 - Removed `XID` type from `swap.rs`, as it is equivalent to `NID::ixn()` and required duplicating (or genericizing) `Hilo` and `Vhl` types.

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -103,10 +103,10 @@ pub struct BddBase {
 
 impl BddBase {
 
-  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: false}}
+  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: true}}
 
   pub fn new_with_threads(n:usize)->BddBase {
-    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new(), table_shortcircuit: false}}
+    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new(), table_shortcircuit: true}}
 
   /// return (hi, lo) pair for the given nid. used internally
   #[inline] fn tup(&self, n:NID)->(NID,NID) { self.swarm.tup(n) }
@@ -128,9 +128,16 @@ impl BddBase {
 
   /// all-purpose node creation/lookup
   #[inline] pub fn ite(&mut self, f:NID, g:NID, h:NID)->NID {
-    if self.table_shortcircuit {
-      if let Some(r) = crate::tbl::table_ite(f,g,h) { return r; }}
-    self.swarm.ite(f,g,h) }
+    match ITE::norm(f,g,h) {
+      Norm::Nid(n) => n,
+      Norm::Ite(ite) => {
+        if self.table_shortcircuit {
+          if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return r; }}
+        self.swarm.run_swarm_job(ite) }
+      Norm::Not(ite) => {
+        if self.table_shortcircuit {
+          if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return !r; }}
+        !self.swarm.run_swarm_job(ite) }}}
 
 
   /// swap input variables x and y within bdd n
@@ -339,7 +346,7 @@ impl Default for BddBase { fn default() -> Self { Self::new() }}
 
 impl Base for BddBase {
 
-  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: false}}
+  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: true}}
 
   /// nid of y when x is high
   fn when_hi(&mut self, x:VID, y:NID)->NID {

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -97,16 +97,14 @@ impl ITE {
 pub struct BddBase {
   /// allows us to give user-friendly names to specific nodes in the base.
   pub tags: HashMap<String, NID>,
-  pub swarm: BddSwarm, // TODO: nopub
-  /// if true, try to resolve ite() calls via truth tables before entering the swarm.
-  pub table_shortcircuit: bool}
+  pub swarm: BddSwarm} // TODO: nopub
 
 impl BddBase {
 
-  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: true}}
+  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new()}}
 
   pub fn new_with_threads(n:usize)->BddBase {
-    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new(), table_shortcircuit: true}}
+    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new()}}
 
   /// return (hi, lo) pair for the given nid. used internally
   #[inline] fn tup(&self, n:NID)->(NID,NID) { self.swarm.tup(n) }
@@ -131,12 +129,10 @@ impl BddBase {
     match ITE::norm(f,g,h) {
       Norm::Nid(n) => n,
       Norm::Ite(ite) => {
-        if self.table_shortcircuit {
-          if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return r; }}
+        if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return r; }
         self.swarm.run_swarm_job(ite) }
       Norm::Not(ite) => {
-        if self.table_shortcircuit {
-          if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return !r; }}
+        if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return !r; }
         !self.swarm.run_swarm_job(ite) }}}
 
 
@@ -346,7 +342,7 @@ impl Default for BddBase { fn default() -> Self { Self::new() }}
 
 impl Base for BddBase {
 
-  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: true}}
+  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new()}}
 
   /// nid of y when x is high
   fn when_hi(&mut self, x:VID, y:NID)->NID {

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -96,14 +96,16 @@ impl ITE {
 pub struct BddBase {
   /// allows us to give user-friendly names to specific nodes in the base.
   pub tags: HashMap<String, NID>,
-  pub swarm: BddSwarm} // TODO: nopub
+  pub swarm: BddSwarm, // TODO: nopub
+  /// if true, try to resolve ite() calls via truth tables before entering the swarm.
+  pub table_shortcircuit: bool}
 
 impl BddBase {
 
-  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new()}}
+  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: false}}
 
   pub fn new_with_threads(n:usize)->BddBase {
-    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new()}}
+    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new(), table_shortcircuit: false}}
 
   /// return (hi, lo) pair for the given nid. used internally
   #[inline] fn tup(&self, n:NID)->(NID,NID) { self.swarm.tup(n) }
@@ -124,7 +126,10 @@ impl BddBase {
   pub fn  lt(&mut self, x:NID, y:NID)->NID { self.ite(x, O, y) }
 
   /// all-purpose node creation/lookup
-  #[inline] pub fn ite(&mut self, f:NID, g:NID, h:NID)->NID { self.swarm.ite(f,g,h) }
+  #[inline] pub fn ite(&mut self, f:NID, g:NID, h:NID)->NID {
+    if self.table_shortcircuit {
+      if let Some(r) = crate::tbl::table_ite(f,g,h) { return r; }}
+    self.swarm.ite(f,g,h) }
 
 
   /// swap input variables x and y within bdd n
@@ -333,7 +338,7 @@ impl Default for BddBase { fn default() -> Self { Self::new() }}
 
 impl Base for BddBase {
 
-  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new()}}
+  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), table_shortcircuit: false}}
 
   /// nid of y when x is high
   fn when_hi(&mut self, x:VID, y:NID)->NID {

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -6,6 +6,7 @@ use crate::reg::Reg;
 use crate::vhl::Walkable;
 use crate::nid::{NID,O,I};
 use crate::vid::{VID,VidOrdering,topmost_of3};
+use crate::Fun;
 use crate::wip;
 
 mod bdd_sols;
@@ -342,6 +343,16 @@ impl Base for BddBase {
 
   /// nid of y when x is high
   fn when_hi(&mut self, x:VID, y:NID)->NID {
+    if y.is_fun() {
+      if let Some(f) = y.to_fun() {
+        if let Some(pos) = f.var_position(x) {
+          let reduced = f.when(pos, true);
+          let (ar, vs) = f.vars();
+          let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
+          new_vars.remove(pos as usize);
+          let result = crate::tbl::nidfun_to_nid(&reduced, &new_vars);
+          return if y.is_inv() { !result } else { result };
+        } else { return y; }}}
     let yv = y.vid();
     match x.cmp_depth(&yv) {
       VidOrdering::Level => self.tup(y).0,  // x ∧ if(x,th,_) → th
@@ -353,6 +364,16 @@ impl Base for BddBase {
 
   /// nid of y when x is low
   fn when_lo(&mut self, x:VID, y:NID)->NID {
+    if y.is_fun() {
+      if let Some(f) = y.to_fun() {
+        if let Some(pos) = f.var_position(x) {
+          let reduced = f.when(pos, false);
+          let (ar, vs) = f.vars();
+          let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
+          new_vars.remove(pos as usize);
+          let result = crate::tbl::nidfun_to_nid(&reduced, &new_vars);
+          return if y.is_inv() { !result } else { result };
+        } else { return y; }}}
     let yv = y.vid();
     match x.cmp_depth(&yv) {
       VidOrdering::Level => self.tup(y).1,  // ¬x ∧ if(x,_,el) → el

--- a/src/comb.rs
+++ b/src/comb.rs
@@ -1,0 +1,317 @@
+//! Combinatorial number system encoding for variable subsets.
+//!
+//! Encodes a k-element subset of {0..MAX_VAR-1} as a single integer
+//! that fits in 27 bits. Used by table NIDs to specify which variables
+//! a truth table depends on.
+//!
+//! The 27-bit space is partitioned by arity using an offset scheme:
+//!   arity 2: [0, C(N,2))
+//!   arity 3: [C(N,2), C(N,2)+C(N,3))
+//!   arity 4: [C(N,2)+C(N,3), C(N,2)+C(N,3)+C(N,4))
+//!   arity 5: [C(N,2)+..+C(N,4), C(N,2)+..+C(N,5))
+//!
+//! Arity is recovered by checking which range the index falls into.
+
+/// Maximum variable index (exclusive). Variables are 0..MAX_VAR-1.
+pub const MAX_VAR: usize = 110;
+
+/// Maximum number of variables in a table NID.
+pub const MAX_ARITY: u8 = 5;
+
+/// Precomputed Pascal's triangle: PASCAL[n][k] = C(n,k) for n <= MAX_VAR, k <= 5.
+/// We only need k up to 5, so this is a small table.
+pub const PASCAL: [[u32; 6]; MAX_VAR + 1] = {
+  let mut t = [[0u32; 6]; MAX_VAR + 1];
+  let mut n = 0;
+  while n <= MAX_VAR {
+    t[n][0] = 1;
+    let mut k = 1;
+    while k <= 5 && k <= n {
+      t[n][k] = t[n-1][k-1] + t[n-1][k];
+      k += 1;
+    }
+    n += 1;
+  }
+  t
+};
+
+/// C(n,k) via the precomputed table. Returns 0 if k > n or k > 5.
+#[inline]
+pub const fn choose(n: usize, k: usize) -> u32 {
+  if k > 5 || k > n { 0 } else { PASCAL[n][k] }
+}
+
+/// Offset for each arity in the combined index space.
+/// OFFSET[k] is the start of the range for arity k.
+/// Arities 0 and 1 are included for internal use by the Fun trait,
+/// even though they should eventually be normalized to consts/vars.
+pub const OFFSET: [u32; 6] = {
+  let o0: u32 = 0;                           // arity 0: 1 entry (the "no variables" case)
+  let o1: u32 = o0 + 1;                      // arity 1: MAX_VAR entries
+  let o2: u32 = o1 + MAX_VAR as u32;         // arity 2: C(MAX_VAR, 2) entries
+  let o3: u32 = o2 + PASCAL[MAX_VAR][2];
+  let o4: u32 = o3 + PASCAL[MAX_VAR][3];
+  let o5: u32 = o4 + PASCAL[MAX_VAR][4];
+  [o0, o1, o2, o3, o4, o5]
+};
+
+/// Total number of valid indices (must fit in 27 bits).
+pub const TOTAL: u32 = OFFSET[5] + PASCAL[MAX_VAR][5];
+
+/// Encode a sorted slice of variable indices into a combined 27-bit index.
+/// `vars` must be sorted ascending, with length 2..=5, and all values < MAX_VAR.
+///
+/// Uses the combinatorial number system:
+///   index = C(c_0, 1) + C(c_1, 2) + ... + C(c_{k-1}, k)
+/// then adds the arity offset.
+pub fn encode(vars: &[u32]) -> u32 {
+  let k = vars.len();
+  debug_assert!(k <= 5, "arity must be 0..5, got {}", k);
+  debug_assert!(vars.windows(2).all(|w| w[0] < w[1]), "vars must be strictly sorted ascending");
+  debug_assert!(vars.iter().all(|&v| (v as usize) < MAX_VAR), "variable index out of range");
+  if k == 0 { return OFFSET[0]; }
+  if k == 1 { return OFFSET[1] + vars[0]; }
+  let mut idx: u32 = 0;
+  for (i, &c) in vars.iter().enumerate() {
+    idx += PASCAL[c as usize][i + 1];
+  }
+  idx + OFFSET[k]
+}
+
+/// Decode a combined 27-bit index into (arity, variable indices).
+/// Returns (arity, vars) where vars is a fixed-size array with
+/// the first `arity` elements populated (rest are 0).
+pub fn decode(index: u32) -> (u8, [u32; 5]) {
+  let (arity, combinadic) = split(index);
+  let k = arity as usize;
+  let mut vars = [0u32; 5];
+  if k == 0 { return (0, vars); }
+  if k == 1 { vars[0] = combinadic; return (1, vars); }
+  let mut remaining = combinadic;
+  // Decode from highest position down
+  for i in (0..k).rev() {
+    // Find largest c such that C(c, i+1) <= remaining
+    let rank = i + 1;
+    let mut c: usize = 0;
+    while c + 1 < MAX_VAR && PASCAL[c + 1][rank] <= remaining {
+      c += 1;
+    }
+    vars[i] = c as u32;
+    remaining -= PASCAL[c][rank];
+  }
+  debug_assert_eq!(remaining, 0, "decode error: leftover {}", remaining);
+  (arity, vars)
+}
+
+/// Split a combined index into (arity, combinadic within that arity's range).
+#[inline]
+fn split(index: u32) -> (u8, u32) {
+  if index < OFFSET[1] { (0, index - OFFSET[0]) }
+  else if index < OFFSET[2] { (1, index - OFFSET[1]) }
+  else if index < OFFSET[3] { (2, index - OFFSET[2]) }
+  else if index < OFFSET[4] { (3, index - OFFSET[3]) }
+  else if index < OFFSET[5] { (4, index - OFFSET[4]) }
+  else { (5, index - OFFSET[5]) }
+}
+
+/// Fast arity extraction from a combined index.
+#[inline]
+pub fn arity_of(index: u32) -> u8 {
+  split(index).0
+}
+
+/// Extract the top (highest-index) variable without a full decode.
+/// This is performance-critical as it is called from NID::vid().
+pub fn top_var_of(index: u32) -> u32 {
+  let (arity, combinadic) = split(index);
+  let k = arity as usize;
+  if k == 0 { return 0; } // no variables; return 0 as placeholder
+  if k == 1 { return combinadic; } // arity 1: combinadic IS the variable index
+  // The top variable c_{k-1} is the largest c such that C(c, k) <= combinadic
+  let mut c: usize = 0;
+  while c + 1 < MAX_VAR && PASCAL[c + 1][k] <= combinadic {
+    c += 1;
+  }
+  c as u32
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+
+  #[test]
+  fn test_pascal() {
+    assert_eq!(choose(0, 0), 1);
+    assert_eq!(choose(5, 0), 1);
+    assert_eq!(choose(5, 1), 5);
+    assert_eq!(choose(5, 2), 10);
+    assert_eq!(choose(5, 3), 10);
+    assert_eq!(choose(5, 5), 1);
+    assert_eq!(choose(10, 3), 120);
+    assert_eq!(choose(MAX_VAR, 2), 5995);
+    assert_eq!(choose(MAX_VAR, 5), 122_391_522);
+  }
+
+  #[test]
+  fn test_total_fits_27_bits() {
+    assert!(TOTAL < (1 << 27), "total {} must fit in 27 bits (max {})", TOTAL, 1u32 << 27);
+  }
+
+  #[test]
+  fn test_offsets() {
+    assert_eq!(OFFSET[0], 0);
+    assert_eq!(OFFSET[1], 1);
+    assert_eq!(OFFSET[2], 1 + MAX_VAR as u32);
+    assert_eq!(OFFSET[3], OFFSET[2] + 5995);
+    assert_eq!(OFFSET[4], OFFSET[3] + 215_820);
+    assert_eq!(OFFSET[5], OFFSET[4] + 5_773_185);
+  }
+
+  #[test]
+  fn test_encode_decode_roundtrip_arity2() {
+    let vars = [3, 7];
+    let idx = encode(&vars);
+    let (arity, decoded) = decode(idx);
+    assert_eq!(arity, 2);
+    assert_eq!(&decoded[..2], &vars);
+  }
+
+  #[test]
+  fn test_encode_decode_roundtrip_arity3() {
+    let vars = [1, 5, 9];
+    let idx = encode(&vars);
+    let (arity, decoded) = decode(idx);
+    assert_eq!(arity, 3);
+    assert_eq!(&decoded[..3], &vars);
+  }
+
+  #[test]
+  fn test_encode_decode_roundtrip_arity4() {
+    let vars = [0, 2, 4, 6];
+    let idx = encode(&vars);
+    let (arity, decoded) = decode(idx);
+    assert_eq!(arity, 4);
+    assert_eq!(&decoded[..4], &vars);
+  }
+
+  #[test]
+  fn test_encode_decode_roundtrip_arity5() {
+    let vars = [0, 1, 2, 3, 4];
+    let idx = encode(&vars);
+    let (arity, decoded) = decode(idx);
+    assert_eq!(arity, 5);
+    assert_eq!(&decoded[..5], &vars);
+  }
+
+  #[test]
+  fn test_encode_decode_max_vars() {
+    // largest possible variable indices for arity 5
+    let vars = [105, 106, 107, 108, 109];
+    let idx = encode(&vars);
+    assert!(idx < (1 << 27));
+    let (arity, decoded) = decode(idx);
+    assert_eq!(arity, 5);
+    assert_eq!(&decoded[..5], &vars);
+  }
+
+  #[test]
+  fn test_top_var_of() {
+    let vars = [3, 7, 42];
+    let idx = encode(&vars);
+    assert_eq!(top_var_of(idx), 42);
+
+    let vars2 = [0, 109];
+    let idx2 = encode(&vars2);
+    assert_eq!(top_var_of(idx2), 109);
+
+    let vars3 = [0, 1, 2, 3, 4];
+    let idx3 = encode(&vars3);
+    assert_eq!(top_var_of(idx3), 4);
+  }
+
+  #[test]
+  fn test_arity_of() {
+    assert_eq!(arity_of(encode(&[0, 1])), 2);
+    assert_eq!(arity_of(encode(&[0, 1, 2])), 3);
+    assert_eq!(arity_of(encode(&[0, 1, 2, 3])), 4);
+    assert_eq!(arity_of(encode(&[0, 1, 2, 3, 4])), 5);
+  }
+
+  #[test]
+  fn test_exhaustive_arity2_small() {
+    // encode and decode all 2-element subsets of {0..9}
+    for a in 0u32..10 {
+      for b in (a+1)..10 {
+        let vars = [a, b];
+        let idx = encode(&vars);
+        let (arity, decoded) = decode(idx);
+        assert_eq!(arity, 2, "failed for {:?}", vars);
+        assert_eq!(&decoded[..2], &vars, "roundtrip failed for {:?}", vars);
+      }
+    }
+  }
+
+  #[test]
+  fn test_exhaustive_arity3_small() {
+    for a in 0u32..8 {
+      for b in (a+1)..9 {
+        for c in (b+1)..10 {
+          let vars = [a, b, c];
+          let idx = encode(&vars);
+          let (arity, decoded) = decode(idx);
+          assert_eq!(arity, 3, "failed for {:?}", vars);
+          assert_eq!(&decoded[..3], &vars, "roundtrip failed for {:?}", vars);
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn test_exhaustive_arity5_tiny() {
+    // all 5-element subsets of {0..8}: C(9,5) = 126
+    for a in 0u32..5 {
+      for b in (a+1)..6 {
+        for c in (b+1)..7 {
+          for d in (c+1)..8 {
+            for e in (d+1)..9 {
+              let vars = [a, b, c, d, e];
+              let idx = encode(&vars);
+              let (arity, decoded) = decode(idx);
+              assert_eq!(arity, 5, "failed for {:?}", vars);
+              assert_eq!(&decoded[..5], &vars, "roundtrip failed for {:?}", vars);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  #[test]
+  fn test_no_range_overlap() {
+    // The maximum index for each arity should be below the offset for the next
+    let max2 = encode(&[108, 109]);
+    let min3 = encode(&[0, 1, 2]);
+    assert!(max2 < min3, "arity 2 max {} overlaps arity 3 min {}", max2, min3);
+
+    let max3 = encode(&[107, 108, 109]);
+    let min4 = encode(&[0, 1, 2, 3]);
+    assert!(max3 < min4, "arity 3 max {} overlaps arity 4 min {}", max3, min4);
+
+    let max4 = encode(&[106, 107, 108, 109]);
+    let min5 = encode(&[0, 1, 2, 3, 4]);
+    assert!(max4 < min5, "arity 4 max {} overlaps arity 5 min {}", max4, min5);
+  }
+
+  #[test]
+  fn test_encoding_is_unique() {
+    // All arity-2 subsets of {0..19} should produce unique indices
+    let mut indices = std::collections::HashSet::new();
+    for a in 0u32..20 {
+      for b in (a+1)..20 {
+        let idx = encode(&[a, b]);
+        assert!(indices.insert(idx), "duplicate index for [{}, {}]", a, b);
+      }
+    }
+  }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ pub mod vid;
 pub mod nid;    pub use crate::nid::{NID,I,O};
 pub mod fun;    pub use crate::fun::Fun;
 pub mod comb;
+pub mod tbl;
 pub mod reg;    pub use crate::reg::{Reg, RegOps, RegView};
 pub mod vhl;
 pub mod wip;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ pub mod base;   pub use crate::base::{Base, GraphViz};
 pub mod vid;
 pub mod nid;    pub use crate::nid::{NID,I,O};
 pub mod fun;    pub use crate::fun::Fun;
+pub mod comb;
 pub mod reg;    pub use crate::reg::{Reg, RegOps, RegView};
 pub mod vhl;
 pub mod wip;

--- a/src/nid-fun.rs
+++ b/src/nid-fun.rs
@@ -22,8 +22,38 @@ fn select_bits(x:u32, pv:&[u8])->u32 {
   r }
 
 impl NidFun {
-  pub fn tbl(&self)->u32 { self.nid.tbl().unwrap() }
-  pub fn to_nid(&self)->NID { self.nid }}
+  pub fn tbl(&self)->u32 { self.nid.raw().tbl().unwrap() }
+  pub fn to_nid(&self)->NID { self.nid }
+
+  /// The raw combinadic index stored in bits 58-32.
+  /// Masks off all flag bits (INV, VAR, T, RVAR, F) to get just the 27-bit mid-field.
+  #[inline] pub fn combinadic(&self)->u32 {
+    const COMB_MASK: u64 = ((1u64 << 27) - 1) << 32; // bits 58..32
+    ((self.nid.n & COMB_MASK) >> 32) as u32 }
+
+  /// Decode the variable set from the combinadic.
+  pub fn vars(&self)->(u8, [u32; 5]) { crate::comb::decode(self.combinadic()) }
+
+  /// The top (highest-index) variable in this function's variable set.
+  #[inline] pub fn top_vid(&self)->vid::VID {
+    vid::VID::var(crate::comb::top_var_of(self.combinadic())) }
+
+  /// Does this function depend on the given variable?
+  pub fn contains_var(&self, v:vid::VID)->bool {
+    if !v.is_var() { return false }
+    let vi = v.var_ix();
+    let (arity, vs) = self.vars();
+    vs[..arity as usize].contains(&(vi as u32))
+  }
+
+  /// Position of the given variable in the sorted variable set (0 = lowest).
+  pub fn var_position(&self, v:vid::VID)->Option<u8> {
+    if !v.is_var() { return None }
+    let vi = v.var_ix();
+    let (arity, vs) = self.vars();
+    vs[..arity as usize].iter().position(|&x| x == vi as u32).map(|p| p as u8)
+  }
+}
 
 use std::fmt::{Formatter,Debug,Error};
 impl Debug for NidFun {
@@ -50,7 +80,7 @@ impl Fun for NidFun {
   // 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31
 
   #[inline(always)] fn arity(&self)->u8 {
-    (self.nid.n >> 32 & 0xff) as u8 }
+    crate::comb::arity_of(self.combinadic()) }
 
   /// given a function, return the function you'd get if you inverted one or more of the input bits.
   /// bits is a bitmap where setting the (2^i)'s-place bit means to invert the `i`th input.

--- a/src/nid.rs
+++ b/src/nid.rs
@@ -98,11 +98,23 @@ impl fmt::Display for NID {
     if self.is_const() { if self.is_inv() { write!(f, "I") } else { write!(f, "O") } }
     else if self.is_fun() {
       let fnid = self.to_fun().unwrap();
-      let ar:u8 = fnid.arity(); // 2..5 inclusive
-      // !! arity of 1 would just be ID or NOT, which are redundant because of the INV bit
+      let ar:u8 = fnid.arity();
       let ft:u32 = fnid.tbl();
-      if ar == 2 { write!(f, "t{:04b}", ft) }
-      else { write!(f, "f{}.{:X}", ar, ft) }}
+      let (_, vs) = fnid.vars();
+      let va = &vs[..ar as usize];
+      // check if vars are the implicit default [0, 1, ..., ar-1]
+      let is_default = va.iter().enumerate().all(|(i, &v)| v == i as u32);
+      if is_default {
+        if ar == 2 { write!(f, "t{:04b}", ft) }
+        else { write!(f, "f{}.{:X}", ar, ft) }}
+      else {
+        // named-variable format: T{x3,x7:1110} (binary for ar 2, hex otherwise)
+        write!(f, "T{{")?;
+        for (i, &v) in va.iter().enumerate() {
+          if i > 0 { write!(f, ",")?; }
+          write!(f, "x{}", v)?; }
+        if ar == 2 { write!(f, ":{:0width$b}}}", ft, width = 1 << ar) }
+        else { write!(f, ":{:X}}}", ft) }}}
     else {
       if self.is_inv() { write!(f, "!")?; }
       if self.is_vid() { write!(f, "{}", self.vid()) }
@@ -185,6 +197,31 @@ impl FromStr for NID {
               let tb = usize::from_str_radix(&bits, 2).map_err(|_| format!("bad table: {}", word))?;
               Ok(NID::fun(ar as u8, tb as u32).to_nid().inv_if(inv))
             }
+        'T' => {
+            // named-variable format: T{x3,x7:1110} or T{x1,x3,x5:FC}
+            let rest = ch.collect::<String>();
+            if !rest.starts_with('{') || !rest.ends_with('}') {
+              return Err(format!("bad named table (expect T{{...}}): {}", word)); }
+            let inner = &rest[1..rest.len()-1];
+            let colon = inner.find(':').ok_or_else(|| format!("bad named table (no ':'): {}", word))?;
+            let var_part = &inner[..colon];
+            let tbl_part = &inner[colon+1..];
+            let mut vars: Vec<u32> = Vec::new();
+            for vstr in var_part.split(',') {
+              let vstr = vstr.trim();
+              if !vstr.starts_with('x') { return Err(format!("bad var in named table: {}", vstr)); }
+              let vi: u32 = vstr[1..].parse().map_err(|_| format!("bad var index: {}", vstr))?;
+              vars.push(vi); }
+            let ar = vars.len();
+            if ar < 2 || ar > 5 { return Err(format!("bad arity {} in named table", ar)); }
+            let tb = if ar == 2 {
+              usize::from_str_radix(tbl_part, 2).map_err(|_| format!("bad binary table: {}", tbl_part))?
+            } else {
+              if !is_upper_hex(tbl_part) { return Err(format!("hex must be uppercase: {}", tbl_part)); }
+              usize::from_str_radix(tbl_part, 16).map_err(|_| format!("bad hex table: {}", tbl_part))?
+            };
+            Ok(NID::fun_with_vars(&vars, tb as u32).to_nid().inv_if(inv))
+          }
         _ => Err(format!("{}?", word))}}}}}}
 
 
@@ -311,7 +348,28 @@ impl NID {
 
 #[test] fn test_tbl_fmt() {
   assert_eq!("t1110", format!("{}", NID::fun(2, 0b1110).to_nid()));
-  assert_eq!("f3.FC", format!("{}", NID::fun(3, 0xFC).to_nid()));}
+  assert_eq!("f3.FC", format!("{}", NID::fun(3, 0xFC).to_nid()));
+  // named-variable format
+  assert_eq!("T{x3,x7:1110}", format!("{}", NID::fun_with_vars(&[3, 7], 0b1110).to_nid()));
+  assert_eq!("T{x1,x3,x5:FC}", format!("{}", NID::fun_with_vars(&[1, 3, 5], 0xFC).to_nid()));
+}
+
+#[test] fn test_named_tbl_parse() {
+  let n: NID = "T{x3,x7:1110}".parse().unwrap();
+  let f = n.to_fun().unwrap();
+  assert_eq!(f.arity(), 2);
+  assert_eq!(f.tbl(), 0b1110);
+  let (_, vs) = f.vars();
+  assert_eq!(&vs[..2], &[3, 7]);
+  // round-trip
+  assert_eq!(format!("{}", n), "T{x3,x7:1110}");
+
+  let n2: NID = "T{x1,x3,x5:FC}".parse().unwrap();
+  let f2 = n2.to_fun().unwrap();
+  assert_eq!(f2.arity(), 3);
+  assert_eq!(f2.tbl(), 0xFC);
+  assert_eq!(format!("{}", n2), "T{x1,x3,x5:FC}");
+}
 
 include!("nid-fun.rs");
 

--- a/src/nid.rs
+++ b/src/nid.rs
@@ -229,7 +229,12 @@ impl NID {
 
   #[inline(always)] pub fn from_vid(v:vid::VID)->Self { nv(vid_to_bits(v)) }
   #[inline(always)] pub fn from_vid_idx(v:vid::VID, i:usize)->Self { nvi(vid_to_bits(v), i) }
-  #[inline(always)] pub fn vid(&self)->vid::VID { bits_to_vid(vid_bits(*self)) }
+  #[inline(always)] pub fn vid(&self)->vid::VID {
+    if self.is_fun() {
+      const COMB_MASK: u64 = ((1u64 << 27) - 1) << 32;
+      let comb_idx = ((self.n & COMB_MASK) >> 32) as u32;
+      vid::VID::var(crate::comb::top_var_of(comb_idx))
+    } else { bits_to_vid(vid_bits(*self)) }}
   // return a nid that is not tied to a variable
   #[inline(always)] pub fn ixn(ix:usize)->Self { nvi(NOVAR, ix) }
 
@@ -266,8 +271,21 @@ impl NID {
   #[inline(always)] pub fn raw(self)->NID { NID{ n: self.n & !INV }}
 
   /// construct a NID holding a truth table for up to 5 input bits.
+  /// Variables are implicitly x0..x(arity-1).
   #[inline(always)] pub const fn fun(arity:u8, tbl:u32)->NidFun {
-    NidFun { nid: NID { n:F+(((1<<(1<<arity)) -1) & tbl as u64)+((arity as u64)<< 32)}} }
+    let comb_idx = crate::comb::OFFSET[arity as usize];
+    let shift = 1u32 << (arity as u32);
+    let tbl_mask = (1u64 << shift) - 1;
+    NidFun { nid: NID { n: F + (tbl_mask & tbl as u64) + ((comb_idx as u64) << 32) }}}
+
+  /// construct a NID holding a truth table for a function of the given variables.
+  /// `vars` must be sorted ascending, length 2..=5, all values < comb::MAX_VAR.
+  pub fn fun_with_vars(vars:&[u32], tbl:u32)->NidFun {
+    let arity = vars.len() as u8;
+    let comb_idx = crate::comb::encode(vars);
+    let shift = 1u32 << (arity as u32);
+    let tbl_mask = (1u64 << shift) - 1;
+    NidFun { nid: NID { n: F + (tbl_mask & tbl as u64) + ((comb_idx as u64) << 32) }}}
 
   /// is this NID a function (truth table)?
   #[inline(always)] pub fn is_fun(&self)->bool { self.n & F == F }
@@ -281,6 +299,9 @@ impl NID {
   #[inline] pub fn might_depend_on(&self, v:vid::VID)->bool {
     if self.is_const() { false }
     else if self.is_vid() { self.vid() == v }
+    else if self.is_fun() {
+      if let Some(f) = self.to_fun() { f.contains_var(v) } else { false }
+    }
     else { let sv = self.vid(); sv == v || sv.is_above(&v) }}
 
   // -- int conversions used by the dd python package

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -3,10 +3,34 @@
 //! Provides truth table alignment (expanding tables to a common variable set),
 //! bitwise operations on table NIDs, and a `TableBase<T>` decorator that wraps
 //! any `Base` to automatically collapse small subgraphs into table NIDs.
+//!
+//! **Bit ordering note:** Internally, this module uses LSB-first encoding
+//! (bit i = f(row i), where row i means x0=(i&1), x1=((i>>1)&1), ...).
+//! The NidFun/Fun trait uses MSB-first (bit 0 = last row, matching the
+//! `select_bits` convention). Conversion happens at the boundaries:
+//! `nid_to_table` converts MSB→LSB, and `make_table_nid` converts LSB→MSB.
 
 use crate::nid::{NID, NidFun, I, O};
 use crate::vid::VID;
 use crate::Fun;
+
+// ---- bit-order conversion ----
+
+/// Reverse the bit ordering of a truth table within the relevant 2^arity bits.
+/// Converts between LSB-first and MSB-first encodings (the operation is its own inverse).
+fn reverse_bits(tbl: u32, arity: u8) -> u32 {
+  if arity == 0 { return tbl & 1; }
+  let n = 1u32 << arity; // number of entries in the truth table
+  let mask = if arity >= 5 { 0xFFFFFFFFu32 } else { (1u32 << n) - 1 };
+  let tbl = tbl & mask;
+  let mut result = 0u32;
+  for i in 0..n {
+    if tbl & (1 << i) != 0 {
+      result |= 1 << (n - 1 - i);
+    }
+  }
+  result
+}
 
 // ---- truth table alignment ----
 
@@ -98,12 +122,16 @@ pub fn make_table_nid(tbl: u32, vars: &[u32]) -> NID {
     if effective == 0b10u32 { return NID::from_vid(v); }
     else { return !NID::from_vid(v); }
   }
-  // INV normalization: if bit 0 is set, store inverted table with INV flag.
+  // INV normalization: if bit 0 (LSB-first = all-zeros input) is set,
+  // store inverted table with INV flag.
   if effective & 1 == 1 {
     let inv_tbl = !effective & mask;
-    return !NID::fun_with_vars(&vars, inv_tbl).to_nid();
+    let msb = reverse_bits(inv_tbl, arity as u8);
+    return !NID::fun_with_vars(&vars, msb).to_nid();
   }
-  NID::fun_with_vars(&vars, effective).to_nid()
+  // Convert LSB-first → MSB-first for NID storage
+  let msb = reverse_bits(effective, arity as u8);
+  NID::fun_with_vars(&vars, msb).to_nid()
 }
 
 /// Check if variable at position `pos` in a truth table of `arity` variables is unused.
@@ -156,9 +184,10 @@ fn strip_unused_vars(mut tbl: u32, vars: &[u32]) -> (u32, Vec<u32>) {
 }
 
 /// Convert a NidFun (from a Fun::when() result) + remaining variable set to the correct NID.
-/// Handles arity 0 -> const, arity 1 -> variable, arity 2+ -> table NID.
+/// The NidFun stores its table in MSB-first; convert to LSB-first for make_table_nid.
 pub fn nidfun_to_nid(f: &NidFun, vars: &[u32]) -> NID {
-  make_table_nid(f.tbl(), vars)
+  let lsb_tbl = reverse_bits(f.tbl(), vars.len() as u8);
+  make_table_nid(lsb_tbl, vars)
 }
 
 // ---- promoting consts/vars to truth tables for alignment ----
@@ -175,7 +204,7 @@ fn nid_to_table(n: NID) -> Option<(u32, Vec<u32>)> {
   } else if n.is_fun() {
     let f = n.to_fun().unwrap();
     let (ar, vars) = f.vars();
-    let mut tbl = f.tbl();
+    let mut tbl = reverse_bits(f.tbl(), ar); // MSB→LSB conversion
     if n.is_inv() {
       let mask = if ar >= 5 { 0xFFFFFFFFu32 } else { (1u32 << (1u32 << ar)) - 1 };
       tbl ^= mask;
@@ -282,7 +311,7 @@ impl<T: crate::base::Base> crate::base::Base for TableBase<T> {
           let (ar, vs) = f.vars();
           let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
           new_vars.remove(pos as usize);
-          let result = make_table_nid(reduced.tbl(), &new_vars);
+          let result = nidfun_to_nid(&reduced, &new_vars);
           return if n.is_inv() { !result } else { result };
         } else {
           return n; // variable not in set, no change
@@ -300,7 +329,7 @@ impl<T: crate::base::Base> crate::base::Base for TableBase<T> {
           let (ar, vs) = f.vars();
           let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
           new_vars.remove(pos as usize);
-          let result = make_table_nid(reduced.tbl(), &new_vars);
+          let result = nidfun_to_nid(&reduced, &new_vars);
           return if n.is_inv() { !result } else { result };
         } else {
           return n;
@@ -337,6 +366,23 @@ mod tests {
   use super::*;
   use crate::nid::named::*;
 
+  /// Evaluate a NID on a specific input assignment (for testing).
+  /// vars_vals: list of (var_index, bool) pairs.
+  fn eval_nid(n: NID, vars_vals: &[(u32, bool)]) -> bool {
+    if let Some((tbl, vars)) = nid_to_table(n) {
+      // tbl is LSB-first internally
+      let mut row = 0usize;
+      for (pos, &v) in vars.iter().enumerate() {
+        for &(vi, val) in vars_vals {
+          if vi == v && val { row |= 1 << pos; }
+        }
+      }
+      (tbl >> row) & 1 == 1
+    } else {
+      panic!("eval_nid: not a table/const/var NID");
+    }
+  }
+
   #[test]
   fn test_insert_var() {
     // f(a) = a (truth table 0b10) -> insert don't-care at position 0
@@ -365,29 +411,30 @@ mod tests {
 
   #[test]
   fn test_table_and_two_vars() {
-    // x0 AND x1: both are simple variables
     let result = table_and(x0, x1).unwrap();
-    assert!(result.is_fun());
-    let f = result.to_fun().unwrap();
-    assert_eq!(f.arity(), 2);
-    // AND truth table: 0b1000 (row order: 00->0, 01->0, 10->0, 11->1)
-    assert_eq!(f.tbl(), 0b1000);
+    // Verify AND truth table: f(a,b) = a AND b
+    assert!(!eval_nid(result, &[(0,false),(1,false)]));
+    assert!(!eval_nid(result, &[(0,true),(1,false)]));
+    assert!(!eval_nid(result, &[(0,false),(1,true)]));
+    assert!( eval_nid(result, &[(0,true),(1,true)]));
   }
 
   #[test]
   fn test_table_or_two_vars() {
     let result = table_or(x0, x1).unwrap();
-    let f = result.to_fun().unwrap();
-    assert_eq!(f.arity(), 2);
-    assert_eq!(f.tbl(), 0b1110);
+    assert!(!eval_nid(result, &[(0,false),(1,false)]));
+    assert!( eval_nid(result, &[(0,true),(1,false)]));
+    assert!( eval_nid(result, &[(0,false),(1,true)]));
+    assert!( eval_nid(result, &[(0,true),(1,true)]));
   }
 
   #[test]
   fn test_table_xor_two_vars() {
     let result = table_xor(x0, x1).unwrap();
-    let f = result.to_fun().unwrap();
-    assert_eq!(f.arity(), 2);
-    assert_eq!(f.tbl(), 0b0110);
+    assert!(!eval_nid(result, &[(0,false),(1,false)]));
+    assert!( eval_nid(result, &[(0,true),(1,false)]));
+    assert!( eval_nid(result, &[(0,false),(1,true)]));
+    assert!(!eval_nid(result, &[(0,true),(1,true)]));
   }
 
   #[test]
@@ -404,19 +451,16 @@ mod tests {
 
   #[test]
   fn test_table_and_disjoint_vars() {
-    // (x0 AND x1) AND (x2 AND x3) -> should produce a 4-variable table
     let a01 = table_and(x0, x1).unwrap();
     let a23 = table_and(x2, x3).unwrap();
     let result = table_and(a01, a23).unwrap();
-    let f = result.to_fun().unwrap();
-    assert_eq!(f.arity(), 4);
-    let (_, vs) = f.vars();
-    assert_eq!(&vs[..4], &[0, 1, 2, 3]);
+    assert!( eval_nid(result, &[(0,true),(1,true),(2,true),(3,true)]));
+    assert!(!eval_nid(result, &[(0,true),(1,true),(2,true),(3,false)]));
+    assert!(!eval_nid(result, &[(0,false),(1,true),(2,true),(3,true)]));
   }
 
   #[test]
   fn test_table_exceeds_5_vars() {
-    // Create functions on 3 disjoint vars each -> combined = 6 > 5
     let a = table_and(x0, table_and(x1, x2).unwrap()).unwrap();
     let b = table_and(x3, table_and(x4, NID::var(5)).unwrap()).unwrap();
     assert!(table_and(a, b).is_none(), "should fail: 6 vars > 5");
@@ -424,26 +468,24 @@ mod tests {
 
   #[test]
   fn test_table_ite() {
-    // ite(x0, x1, x2) = if x0 then x1 else x2
-    // Signals: x0=0xAA, x1=0xCC, x2=0xF0 (for 3-var 8-bit table)
-    // (x0 & x1) | (~x0 & x2) = 0x88 | 0x50 = 0xD8 = 0b11011000
     let result = table_ite(x0, x1, x2).unwrap();
-    let f = result.to_fun().unwrap();
-    assert_eq!(f.arity(), 3);
-    assert_eq!(f.tbl(), 0b11011000);
+    // if x0 then x1 else x2
+    assert!( eval_nid(result, &[(0,true),(1,true),(2,false)]));  // take x1=T
+    assert!(!eval_nid(result, &[(0,true),(1,false),(2,true)]));  // take x1=F
+    assert!( eval_nid(result, &[(0,false),(1,false),(2,true)])); // take x2=T
+    assert!(!eval_nid(result, &[(0,false),(1,true),(2,false)])); // take x2=F
   }
 
   #[test]
   fn test_table_and_overlapping_vars() {
-    // f(x1, x3) = x1 OR x3, g(x2, x3) = x2 AND x3
-    // (x1 OR x3) AND (x2 AND x3) simplifies to x2 AND x3 (x1 is unused)
-    let f = NID::fun_with_vars(&[1, 3], 0b1110).to_nid();
-    let g = NID::fun_with_vars(&[2, 3], 0b1000).to_nid();
+    // x1 OR x3 (MSB-first: 0b0111) AND x2 AND x3 (MSB-first: 0b0001)
+    // Result simplifies to x2 AND x3
+    let f = NID::fun_with_vars(&[1, 3], 0b0111).to_nid();
+    let g = NID::fun_with_vars(&[2, 3], 0b0001).to_nid();
     let result = table_and(f, g).unwrap();
-    let rf = result.to_fun().unwrap();
-    assert_eq!(rf.arity(), 2);
-    let (_, vs) = rf.vars();
-    assert_eq!(&vs[..2], &[2, 3]);
+    assert!( eval_nid(result, &[(2,true),(3,true)]));
+    assert!(!eval_nid(result, &[(2,true),(3,false)]));
+    assert!(!eval_nid(result, &[(2,false),(3,true)]));
   }
 
   #[test]
@@ -485,12 +527,14 @@ mod tests {
 
   #[test]
   fn test_inv_normalization() {
-    // 0b0111 over {x0, x1} has bit 0 = 1, so it should be stored inverted
+    // LSB-first 0b0111 over {x0, x1} has bit 0 = 1, so it should be stored inverted.
+    // 0b0111 is NAND in LSB-first. Inverted = AND = 0b1000 LSB-first.
     let n = make_table_nid(0b0111, &[0, 1]);
     assert!(n.is_inv(), "should be inverted");
-    let raw = n.raw();
-    let f = raw.to_fun().unwrap();
-    assert_eq!(f.tbl(), 0b1000); // stored as NAND = !(AND)
+    // The underlying function is AND: f(0,0)=0,f(1,0)=0,f(0,1)=0,f(1,1)=1
+    // NAND = !AND: f(0,0)=1,f(1,0)=1,f(0,1)=1,f(1,1)=0
+    assert!( eval_nid(n, &[(0,false),(1,false)])); // NAND(0,0)=1
+    assert!(!eval_nid(n, &[(0,true),(1,true)]));   // NAND(1,1)=0
   }
 
   #[test]

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -245,7 +245,12 @@ pub fn table_or(x: NID, y: NID) -> Option<NID> {
 
 /// Compute ITE(i, t, e) entirely via truth tables.
 pub fn table_ite(i: NID, t: NID, e: NID) -> Option<NID> {
-  if quick_arity(i) + quick_arity(t) + quick_arity(e) > 5 { return None; }
+  // Bail early if we can't possibly fit in 5 vars.
+  // Use max(at,ae)+ai as a tighter bound than at+ae+ai since t and e often
+  // share variables (e.g. xor(a,b) = ite(a,!b,b) where t and e overlap fully).
+  let ai = quick_arity(i); let at = quick_arity(t); let ae = quick_arity(e);
+  let upper = ai + at.max(ae);
+  if upper > 5 { return None; }
   let si = nid_to_small(i)?;
   let st = nid_to_small(t)?;
   let se = nid_to_small(e)?;

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -23,7 +23,46 @@ use crate::Fun;
 #[inline] fn tbl_mask(arity: u8) -> u32 {
   if arity >= 5 { 0xFFFFFFFF } else { (1u32 << n_entries(arity)) - 1 }}
 
-// ---- truth table alignment ----
+// ---- stack-allocated small table ----
+
+/// A truth table with its variable set, fully stack-allocated.
+#[derive(Clone, Copy)]
+struct SmallTbl {
+  tbl: u32,
+  vars: [u32; 5],
+  arity: u8,
+}
+
+impl SmallTbl {
+  #[inline] fn var_slice(&self) -> &[u32] { &self.vars[..self.arity as usize] }
+}
+
+/// Quick arity of a NID (0 for const, 1 for var, arity for fun, 6 for BDD nodes).
+#[inline] fn quick_arity(n: NID) -> u8 {
+  if n.is_const() { 0 }
+  else if n.is_var() { 1 }   // real variables only, not virtual
+  else if n.is_fun() { n.to_fun().unwrap().arity() }
+  else { 6 }
+}
+
+/// Extract a SmallTbl from a NID.  Returns None for BDD nodes and virtual variables.
+#[inline] fn nid_to_small(n: NID) -> Option<SmallTbl> {
+  if n.is_const() {
+    Some(SmallTbl { tbl: if n == I { 0xFFFFFFFF } else { 0 }, vars: [0;5], arity: 0 })
+  } else if n.is_var() {   // real variables only
+    let vi = n.vid().var_ix() as u32;
+    let tbl = if n.is_inv() { 0b10u32 } else { 0b01u32 };
+    Some(SmallTbl { tbl, vars: [vi, 0, 0, 0, 0], arity: 1 })
+  } else if n.is_fun() {
+    let f = n.to_fun().unwrap();
+    let (ar, vars) = f.vars();
+    let mut tbl = f.tbl();
+    if n.is_inv() { tbl ^= tbl_mask(ar); }
+    Some(SmallTbl { tbl, vars, arity: ar })
+  } else { None }
+}
+
+// ---- truth table alignment (no heap allocation) ----
 
 /// Insert a "don't care" variable at position `pos` in a truth table of `arity`
 /// variables (MSB-first).  Returns the expanded table (arity+1 variables).
@@ -32,7 +71,6 @@ fn insert_var(tbl: u32, arity: u8, pos: u8) -> u32 {
   let n_new = n_old << 1;
   let mut result: u32 = 0;
   for j in 0..n_new {
-    // Remove bit at position `pos` from entry index j to get original index.
     let hi = (j >> (pos + 1)) << pos;
     let lo = j & ((1 << pos) - 1);
     let orig = hi | lo;
@@ -42,8 +80,7 @@ fn insert_var(tbl: u32, arity: u8, pos: u8) -> u32 {
   result
 }
 
-/// Expand a truth table's variable set to a target variable set (MSB-first).
-/// `src_vars` must be a subset of `dst_vars` (both sorted ascending).
+/// Expand a truth table from `src_vars` to `dst_vars` (MSB-first).
 fn expand_table(tbl: u32, src_vars: &[u32], dst_vars: &[u32]) -> u32 {
   let mut result = tbl;
   let mut current_arity = src_vars.len() as u8;
@@ -59,26 +96,45 @@ fn expand_table(tbl: u32, src_vars: &[u32], dst_vars: &[u32]) -> u32 {
   result
 }
 
-/// Align two table NIDs to a common variable set.
-/// Returns None if the combined variable count exceeds 5.
-pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
-  let (ar_a, vars_a) = a.vars();
-  let (ar_b, vars_b) = b.vars();
-  let va = &vars_a[..ar_a as usize];
-  let vb = &vars_b[..ar_b as usize];
-  let mut combined = Vec::with_capacity(5);
+/// Merge two sorted variable slices into a fixed-size array.
+/// Returns (merged_vars, merged_len) or None if len > 5.
+#[inline] fn merge_small(va: &[u32], vb: &[u32]) -> Option<([u32; 5], u8)> {
+  let mut out = [0u32; 5];
+  let mut len = 0u8;
   let (mut ia, mut ib) = (0, 0);
   while ia < va.len() && ib < vb.len() {
-    if va[ia] < vb[ib] { combined.push(va[ia]); ia += 1; }
-    else if va[ia] > vb[ib] { combined.push(vb[ib]); ib += 1; }
-    else { combined.push(va[ia]); ia += 1; ib += 1; }
+    if len >= 5 && va[ia] != vb[ib] { return None; }
+    if va[ia] < vb[ib] { out[len as usize] = va[ia]; ia += 1; }
+    else if va[ia] > vb[ib] { out[len as usize] = vb[ib]; ib += 1; }
+    else { out[len as usize] = va[ia]; ia += 1; ib += 1; }
+    len += 1;
   }
-  while ia < va.len() { combined.push(va[ia]); ia += 1; }
-  while ib < vb.len() { combined.push(vb[ib]); ib += 1; }
-  if combined.len() > 5 { return None; }
-  let ta = expand_table(a.tbl(), va, &combined);
-  let tb = expand_table(b.tbl(), vb, &combined);
-  Some((ta, tb, combined))
+  while ia < va.len() { if len > 5 { return None; } out[len as usize] = va[ia]; ia += 1; len += 1; }
+  while ib < vb.len() { if len > 5 { return None; } out[len as usize] = vb[ib]; ib += 1; len += 1; }
+  if len > 5 { None } else { Some((out, len)) }
+}
+
+/// Align two SmallTbls to a common variable set.
+fn align2(a: &SmallTbl, b: &SmallTbl) -> Option<(u32, u32, [u32; 5], u8)> {
+  let (vars, len) = merge_small(a.var_slice(), b.var_slice())?;
+  let dst = &vars[..len as usize];
+  let ta = expand_table(a.tbl, a.var_slice(), dst);
+  let tb = expand_table(b.tbl, b.var_slice(), dst);
+  Some((ta, tb, vars, len))
+}
+
+/// Align three SmallTbls to a common variable set.
+fn align3(a: &SmallTbl, b: &SmallTbl, c: &SmallTbl)
+  -> Option<(u32, u32, u32, [u32; 5], u8)>
+{
+  // merge a+b first, then merge with c
+  let (ab_vars, ab_len) = merge_small(a.var_slice(), b.var_slice())?;
+  let (vars, len) = merge_small(&ab_vars[..ab_len as usize], c.var_slice())?;
+  let dst = &vars[..len as usize];
+  let ta = expand_table(a.tbl, a.var_slice(), dst);
+  let tb = expand_table(b.tbl, b.var_slice(), dst);
+  let tc = expand_table(c.tbl, c.var_slice(), dst);
+  Some((ta, tb, tc, vars, len))
 }
 
 // ---- constructing result table NIDs from raw truth tables ----
@@ -89,7 +145,6 @@ pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
 /// - otherwise → table NID (with INV normalisation)
 pub fn make_table_nid(tbl: u32, vars: &[u32]) -> NID {
   if vars.is_empty() {
-    // arity 0: bit 0 = the single entry
     return if tbl & 1 == 0 { O } else { I }; }
   let (tbl, vars) = strip_unused_vars(tbl, vars);
   let arity = vars.len() as u8;
@@ -97,10 +152,8 @@ pub fn make_table_nid(tbl: u32, vars: &[u32]) -> NID {
   let effective = tbl & mask;
   if effective == 0 { return O; }
   if effective == mask { return I; }
-  // single variable?
   if arity == 1 {
     let v = VID::var(vars[0]);
-    // MSB-first arity-1: identity = 0b01, negation = 0b10
     return if effective == 0b01 { NID::from_vid(v) } else { !NID::from_vid(v) };
   }
   // INV normalisation: if f(0,0,…,0) = 1 (MSB is set), store ¬f and set INV.
@@ -119,11 +172,8 @@ pub fn nidfun_to_nid(f: &NidFun, vars: &[u32]) -> NID {
 
 // ---- degenerate variable detection (MSB-first) ----
 
-/// Is variable at position `pos` unused in a truth table of `arity` variables?
 fn var_is_unused(tbl: u32, arity: u8, pos: u8) -> bool {
   let n = n_entries(arity);
-  // For every pair of entries (i, i ^ (1<<pos)), check that they agree.
-  // We only need to check entries where bit `pos` is 0.
   for i in 0..n {
     if (i >> pos) & 1 == 0 {
       let j = i | (1 << pos);
@@ -135,7 +185,6 @@ fn var_is_unused(tbl: u32, arity: u8, pos: u8) -> bool {
   true
 }
 
-/// Remove variable at position `pos` from a truth table (MSB-first).
 fn remove_var(tbl: u32, arity: u8, pos: u8) -> u32 {
   let n_old = n_entries(arity);
   let n_new = n_old >> 1;
@@ -151,7 +200,6 @@ fn remove_var(tbl: u32, arity: u8, pos: u8) -> u32 {
   result
 }
 
-/// Strip unused variables from a truth table, returning the reduced table and variable list.
 fn strip_unused_vars(mut tbl: u32, vars: &[u32]) -> (u32, Vec<u32>) {
   let mut remaining: Vec<u32> = vars.to_vec();
   let mut pos = 0u8;
@@ -166,92 +214,57 @@ fn strip_unused_vars(mut tbl: u32, vars: &[u32]) -> (u32, Vec<u32>) {
   (tbl, remaining)
 }
 
-// ---- promoting consts/vars to truth tables for alignment ----
-
-/// Get the truth table (MSB-first) and variable set for any "small" NID.
-/// Returns None for BDD nodes.
-fn nid_to_table(n: NID) -> Option<(u32, Vec<u32>)> {
-  if n.is_const() {
-    Some((if n == I { 0xFFFFFFFF } else { 0 }, vec![]))
-  } else if n.is_var() {
-    let vi = n.vid().var_ix() as u32;
-    // MSB-first arity-1: identity = 0b01
-    let tbl = if n.is_inv() { 0b10u32 } else { 0b01u32 };
-    Some((tbl, vec![vi]))
-  } else if n.is_fun() {
-    let f = n.to_fun().unwrap();
-    let (ar, vars) = f.vars();
-    let mut tbl = f.tbl();  // already MSB-first
-    if n.is_inv() { tbl ^= tbl_mask(ar); }
-    Some((tbl, vars[..ar as usize].to_vec()))
-  } else {
-    None
-  }
-}
-
-/// Merge two sorted variable lists.
-fn merge_vars(va: &[u32], vb: &[u32]) -> Vec<u32> {
-  let mut combined = Vec::with_capacity(va.len() + vb.len());
-  let (mut ia, mut ib) = (0, 0);
-  while ia < va.len() && ib < vb.len() {
-    if va[ia] < vb[ib] { combined.push(va[ia]); ia += 1; }
-    else if va[ia] > vb[ib] { combined.push(vb[ib]); ib += 1; }
-    else { combined.push(va[ia]); ia += 1; ib += 1; }
-  }
-  while ia < va.len() { combined.push(va[ia]); ia += 1; }
-  while ib < vb.len() { combined.push(vb[ib]); ib += 1; }
-  combined
-}
-
-/// Align two NIDs to a common variable set. Returns None if either is a BDD
-/// node or combined vars > 5.
-fn align_nids(a: NID, b: NID) -> Option<(u32, u32, Vec<u32>)> {
-  let (ta, va) = nid_to_table(a)?;
-  let (tb, vb) = nid_to_table(b)?;
-  let combined = merge_vars(&va, &vb);
-  if combined.len() > 5 { return None; }
-  Some((expand_table(ta, &va, &combined),
-        expand_table(tb, &vb, &combined),
-        combined))
-}
-
-/// Align three NIDs to a common variable set.
-fn align_three(i: NID, t: NID, e: NID) -> Option<(u32, u32, u32, Vec<u32>)> {
-  let (ti, vi) = nid_to_table(i)?;
-  let (tt, vt) = nid_to_table(t)?;
-  let (te, ve) = nid_to_table(e)?;
-  let combined = merge_vars(&merge_vars(&vi, &vt), &ve);
-  if combined.len() > 5 { return None; }
-  Some((expand_table(ti, &vi, &combined),
-        expand_table(tt, &vt, &combined),
-        expand_table(te, &ve, &combined),
-        combined))
-}
-
 // ---- table-level operations ----
 
 /// Compute AND of two NIDs entirely via truth tables.
 pub fn table_and(x: NID, y: NID) -> Option<NID> {
-  let (tx, ty, vars) = align_nids(x, y)?;
-  Some(make_table_nid(tx & ty, &vars))
+  if quick_arity(x) + quick_arity(y) > 5 { return None; }
+  let a = nid_to_small(x)?;
+  let b = nid_to_small(y)?;
+  let (ta, tb, vars, len) = align2(&a, &b)?;
+  Some(make_table_nid(ta & tb, &vars[..len as usize]))
 }
 
 /// Compute XOR of two NIDs entirely via truth tables.
 pub fn table_xor(x: NID, y: NID) -> Option<NID> {
-  let (tx, ty, vars) = align_nids(x, y)?;
-  Some(make_table_nid(tx ^ ty, &vars))
+  if quick_arity(x) + quick_arity(y) > 5 { return None; }
+  let a = nid_to_small(x)?;
+  let b = nid_to_small(y)?;
+  let (ta, tb, vars, len) = align2(&a, &b)?;
+  Some(make_table_nid(ta ^ tb, &vars[..len as usize]))
 }
 
 /// Compute OR of two NIDs entirely via truth tables.
 pub fn table_or(x: NID, y: NID) -> Option<NID> {
-  let (tx, ty, vars) = align_nids(x, y)?;
-  Some(make_table_nid(tx | ty, &vars))
+  if quick_arity(x) + quick_arity(y) > 5 { return None; }
+  let a = nid_to_small(x)?;
+  let b = nid_to_small(y)?;
+  let (ta, tb, vars, len) = align2(&a, &b)?;
+  Some(make_table_nid(ta | tb, &vars[..len as usize]))
 }
 
 /// Compute ITE(i, t, e) entirely via truth tables.
 pub fn table_ite(i: NID, t: NID, e: NID) -> Option<NID> {
-  let (ti, tt, te, vars) = align_three(i, t, e)?;
-  Some(make_table_nid((ti & tt) | (!ti & te), &vars))
+  if quick_arity(i) + quick_arity(t) + quick_arity(e) > 5 { return None; }
+  let si = nid_to_small(i)?;
+  let st = nid_to_small(t)?;
+  let se = nid_to_small(e)?;
+  let (ti, tt, te, vars, len) = align3(&si, &st, &se)?;
+  Some(make_table_nid((ti & tt) | (!ti & te), &vars[..len as usize]))
+}
+
+
+// ---- public helpers for external callers (vhl.rs, bdd.rs) ----
+
+/// Align two table NIDs to a common variable set.
+/// Returns None if the combined variable count exceeds 5.
+pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
+  let (ar_a, vars_a) = a.vars();
+  let (ar_b, vars_b) = b.vars();
+  let sa = SmallTbl { tbl: a.tbl(), vars: vars_a, arity: ar_a };
+  let sb = SmallTbl { tbl: b.tbl(), vars: vars_b, arity: ar_b };
+  let (ta, tb, vars, len) = align2(&sa, &sb)?;
+  Some((ta, tb, vars[..len as usize].to_vec()))
 }
 
 
@@ -321,18 +334,15 @@ mod tests {
 
   /// Evaluate a NID on a specific input assignment (MSB-first convention).
   fn eval_nid(n: NID, vars_vals: &[(u32, bool)]) -> bool {
-    if let Some((tbl, vars)) = nid_to_table(n) {
-      let nn = n_entries(vars.len() as u8);
-      let mut row = 0u32;
-      for (pos, &v) in vars.iter().enumerate() {
-        for &(vi, val) in vars_vals {
-          if vi == v && val { row |= 1 << pos; }
-        }
+    let s = nid_to_small(n).expect("eval_nid: not a table/const/var NID");
+    let nn = n_entries(s.arity);
+    let mut row = 0u32;
+    for (pos, &v) in s.var_slice().iter().enumerate() {
+      for &(vi, val) in vars_vals {
+        if vi == v && val { row |= 1 << pos; }
       }
-      (tbl >> (nn - 1 - row)) & 1 == 1
-    } else {
-      panic!("eval_nid: not a table/const/var NID");
     }
+    (s.tbl >> (nn - 1 - row)) & 1 == 1
   }
 
   #[test]
@@ -493,5 +503,19 @@ mod tests {
     assert_eq!(table_xor(x0, x0).unwrap(), O);
     let a = table_and(x0, x1).unwrap();
     assert_eq!(table_xor(a, a).unwrap(), O);
+  }
+
+  #[test]
+  fn test_early_bailout() {
+    // BDD nodes (not const/var/fun) should return None instantly
+    let bdd_nid = NID::from_vid_idx(VID::var(0), 42);
+    assert!(table_and(bdd_nid, x0).is_none());
+    assert!(table_ite(bdd_nid, x0, x1).is_none());
+
+    // Arity sum > 5 should bail before any real work
+    let big = table_and(x0, table_and(x1, x2).unwrap()).unwrap(); // arity 3
+    let big2 = table_and(x3, table_and(x4, NID::var(5)).unwrap()).unwrap(); // arity 3
+    // 3 + 3 = 6 > 5, bails at the arity check
+    assert!(table_and(big, big2).is_none());
   }
 }

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -83,6 +83,9 @@ pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
 /// - single-variable -> var NID or !var NID
 /// - otherwise -> table NID
 pub fn make_table_nid(tbl: u32, vars: &[u32]) -> NID {
+  if vars.is_empty() { return if tbl & 1 == 0 { O } else { I }; }
+  // Strip degenerate variables then normalize.
+  let (tbl, vars) = strip_unused_vars(tbl, vars);
   let arity = vars.len();
   let mask = if arity >= 5 { 0xFFFFFFFFu32 } else { (1u32 << (1u32 << arity)) - 1 };
   let effective = tbl & mask;
@@ -92,12 +95,64 @@ pub fn make_table_nid(tbl: u32, vars: &[u32]) -> NID {
   // single variable?
   if arity == 1 {
     let v = VID::var(vars[0]);
-    let var_pattern = 0b10u32; // truth table for identity: f(x)=x
-    if effective == var_pattern { return NID::from_vid(v); }
+    if effective == 0b10u32 { return NID::from_vid(v); }
     else { return !NID::from_vid(v); }
   }
-  // general table NID
-  NID::fun_with_vars(vars, effective).to_nid()
+  // INV normalization: if bit 0 is set, store inverted table with INV flag.
+  if effective & 1 == 1 {
+    let inv_tbl = !effective & mask;
+    return !NID::fun_with_vars(&vars, inv_tbl).to_nid();
+  }
+  NID::fun_with_vars(&vars, effective).to_nid()
+}
+
+/// Check if variable at position `pos` in a truth table of `arity` variables is unused.
+/// A variable is unused if setting it to 0 or 1 gives the same result.
+fn var_is_unused(tbl: u32, arity: u8, pos: u8) -> bool {
+  let block = 1u32 << pos;
+  // Mask that selects every other group of `block` bits
+  let mut lo_mask: u32 = 0;
+  let n = 1u32 << arity;
+  let mut i = 0u32;
+  while i < n {
+    // bits i..i+block have the variable = 0
+    for j in 0..block { lo_mask |= 1 << (i + j); }
+    i += 2 * block;
+  }
+  let lo_val = tbl & lo_mask;
+  let hi_val = (tbl >> block) & lo_mask;
+  lo_val == hi_val
+}
+
+/// Strip unused variables from a truth table, returning the reduced table and variable list.
+fn strip_unused_vars(mut tbl: u32, vars: &[u32]) -> (u32, Vec<u32>) {
+  let mut remaining: Vec<u32> = vars.to_vec();
+  let mut pos = 0u8;
+  while (pos as usize) < remaining.len() {
+    if var_is_unused(tbl, remaining.len() as u8, pos) {
+      // Remove variable at this position: collapse the table
+      let block = 1u32 << pos;
+      let arity = remaining.len() as u8;
+      let n = 1u32 << arity;
+      let mut new_tbl: u32 = 0;
+      let mut src = 0u32;
+      let mut dst = 0u32;
+      while src < n {
+        for _ in 0..block {
+          new_tbl |= ((tbl >> src) & 1) << dst;
+          src += 1;
+          dst += 1;
+        }
+        src += block; // skip the duplicate block
+      }
+      tbl = new_tbl;
+      remaining.remove(pos as usize);
+      // Don't increment pos: the next variable shifted into this position
+    } else {
+      pos += 1;
+    }
+  }
+  (tbl, remaining)
 }
 
 /// Convert a NidFun (from a Fun::when() result) + remaining variable set to the correct NID.
@@ -380,14 +435,15 @@ mod tests {
 
   #[test]
   fn test_table_and_overlapping_vars() {
-    // f(x1, x3) AND g(x2, x3) -> combined {x1, x2, x3}, 3 vars
-    let f = NID::fun_with_vars(&[1, 3], 0b1110).to_nid(); // x1 OR x3
-    let g = NID::fun_with_vars(&[2, 3], 0b1000).to_nid(); // x2 AND x3
+    // f(x1, x3) = x1 OR x3, g(x2, x3) = x2 AND x3
+    // (x1 OR x3) AND (x2 AND x3) simplifies to x2 AND x3 (x1 is unused)
+    let f = NID::fun_with_vars(&[1, 3], 0b1110).to_nid();
+    let g = NID::fun_with_vars(&[2, 3], 0b1000).to_nid();
     let result = table_and(f, g).unwrap();
     let rf = result.to_fun().unwrap();
-    assert_eq!(rf.arity(), 3);
+    assert_eq!(rf.arity(), 2);
     let (_, vs) = rf.vars();
-    assert_eq!(&vs[..3], &[1, 2, 3]);
+    assert_eq!(&vs[..2], &[2, 3]);
   }
 
   #[test]
@@ -400,5 +456,49 @@ mod tests {
     assert_eq!(make_table_nid(0b10, &[3]), NID::var(3));
     // single var inverted
     assert_eq!(make_table_nid(0b01, &[3]), !NID::var(3));
+  }
+
+  #[test]
+  fn test_strip_unused_vars() {
+    // x0 AND x1 = 0b1000. Table truly depends on both -> no change.
+    let (tbl, vars) = strip_unused_vars(0b1000, &[0, 1]);
+    assert_eq!(vars, vec![0, 1]);
+    assert_eq!(tbl, 0b1000);
+
+    // Table 0b1010 over {x0, x1} = just x0 (doesn't depend on x1)
+    let (tbl, vars) = strip_unused_vars(0b1010, &[0, 1]);
+    assert_eq!(vars, vec![0]);
+    assert_eq!(tbl, 0b10); // reduced to 1-var table for x0
+
+    // Table 0b1100 over {x0, x1} = just x1 (doesn't depend on x0)
+    let (tbl, vars) = strip_unused_vars(0b1100, &[0, 1]);
+    assert_eq!(vars, vec![1]);
+    assert_eq!(tbl, 0b10);
+  }
+
+  #[test]
+  fn test_make_table_nid_removes_unused() {
+    // make_table_nid should detect that 0b1010 over {x0, x1} only depends on x0
+    let n = make_table_nid(0b1010, &[0, 1]);
+    assert_eq!(n, x0);
+  }
+
+  #[test]
+  fn test_inv_normalization() {
+    // 0b0111 over {x0, x1} has bit 0 = 1, so it should be stored inverted
+    let n = make_table_nid(0b0111, &[0, 1]);
+    assert!(n.is_inv(), "should be inverted");
+    let raw = n.raw();
+    let f = raw.to_fun().unwrap();
+    assert_eq!(f.tbl(), 0b1000); // stored as NAND = !(AND)
+  }
+
+  #[test]
+  fn test_table_xor_degenerate_result() {
+    // x0 XOR x0 = O (via table operation)
+    assert_eq!(table_xor(x0, x0).unwrap(), O);
+    // (x0 AND x1) XOR (x0 AND x1) = O
+    let a = table_and(x0, x1).unwrap();
+    assert_eq!(table_xor(a, a).unwrap(), O);
   }
 }

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -273,63 +273,6 @@ pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
 }
 
 
-// ---- TableBase decorator ----
-
-/// A decorator around any `Base` that automatically computes operations
-/// on table NIDs (and constants/variables) without entering the BDD pipeline.
-pub struct TableBase<T: crate::base::Base> { pub base: T }
-
-impl<T: crate::base::Base> crate::base::Base for TableBase<T> {
-  crate::inherit![new, def, tag, get, sub, dot];
-
-  fn when_hi(&mut self, v:VID, n:NID)->NID {
-    if n.is_fun() {
-      if let Some(f) = n.to_fun() {
-        if let Some(pos) = f.var_position(v) {
-          let reduced = f.when(pos, true);
-          let (ar, vs) = f.vars();
-          let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
-          new_vars.remove(pos as usize);
-          let result = nidfun_to_nid(&reduced, &new_vars);
-          return if n.is_inv() { !result } else { result };
-        } else { return n; }}}
-    self.base.when_hi(v, n)
-  }
-
-  fn when_lo(&mut self, v:VID, n:NID)->NID {
-    if n.is_fun() {
-      if let Some(f) = n.to_fun() {
-        if let Some(pos) = f.var_position(v) {
-          let reduced = f.when(pos, false);
-          let (ar, vs) = f.vars();
-          let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
-          new_vars.remove(pos as usize);
-          let result = nidfun_to_nid(&reduced, &new_vars);
-          return if n.is_inv() { !result } else { result };
-        } else { return n; }}}
-    self.base.when_lo(v, n)
-  }
-
-  fn and(&mut self, x:NID, y:NID)->NID {
-    if let Some(r) = table_and(x, y) { return r; }
-    self.base.and(x, y)
-  }
-
-  fn xor(&mut self, x:NID, y:NID)->NID {
-    if let Some(r) = table_xor(x, y) { return r; }
-    self.base.xor(x, y)
-  }
-
-  fn or(&mut self, x:NID, y:NID)->NID {
-    if let Some(r) = table_or(x, y) { return r; }
-    self.base.or(x, y)
-  }
-
-  fn ite(&mut self, i:NID, t:NID, e:NID)->NID {
-    if let Some(r) = table_ite(i, t, e) { return r; }
-    self.base.ite(i, t, e)
-  }
-}
 
 
 #[cfg(test)]

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -4,71 +4,54 @@
 //! bitwise operations on table NIDs, and a `TableBase<T>` decorator that wraps
 //! any `Base` to automatically collapse small subgraphs into table NIDs.
 //!
-//! **Bit ordering note:** Internally, this module uses LSB-first encoding
-//! (bit i = f(row i), where row i means x0=(i&1), x1=((i>>1)&1), ...).
-//! The NidFun/Fun trait uses MSB-first (bit 0 = last row, matching the
-//! `select_bits` convention). Conversion happens at the boundaries:
-//! `nid_to_table` converts MSB→LSB, and `make_table_nid` converts LSB→MSB.
+//! **Bit ordering:** MSB-first, matching the NidFun / `select_bits` convention.
+//! Entry i (where variable p has value `(i>>p)&1`) is stored at bit `(N-1-i)`
+//! in the u32.  For 5 variables (N=32), entry 0 is bit 31 and entry 31 is bit 0.
+//!
+//! Variable signals (arity 5):
+//!   x0 = 0x55555555  x1 = 0x33333333  x2 = 0x0F0F0F0F
+//!   x3 = 0x00FF00FF  x4 = 0x0000FFFF
 
 use crate::nid::{NID, NidFun, I, O};
 use crate::vid::VID;
 use crate::Fun;
 
-// ---- bit-order conversion ----
+/// Number of truth-table entries for the given arity.
+#[inline] fn n_entries(arity: u8) -> u32 { 1u32 << arity }
 
-/// Reverse the bit ordering of a truth table within the relevant 2^arity bits.
-/// Converts between LSB-first and MSB-first encodings (the operation is its own inverse).
-fn reverse_bits(tbl: u32, arity: u8) -> u32 {
-  if arity == 0 { return tbl & 1; }
-  let n = 1u32 << arity; // number of entries in the truth table
-  let mask = if arity >= 5 { 0xFFFFFFFFu32 } else { (1u32 << n) - 1 };
-  let tbl = tbl & mask;
-  let mut result = 0u32;
-  for i in 0..n {
-    if tbl & (1 << i) != 0 {
-      result |= 1 << (n - 1 - i);
-    }
-  }
-  result
-}
+/// Bitmask covering all truth-table bits for the given arity.
+#[inline] fn tbl_mask(arity: u8) -> u32 {
+  if arity >= 5 { 0xFFFFFFFF } else { (1u32 << n_entries(arity)) - 1 }}
 
 // ---- truth table alignment ----
 
-/// Insert a "don't care" variable at position `pos` in a truth table of `arity` variables.
-/// The new variable does not affect the output: each block of 2^pos entries is duplicated.
-/// Returns the expanded table (arity+1 variables).
+/// Insert a "don't care" variable at position `pos` in a truth table of `arity`
+/// variables (MSB-first).  Returns the expanded table (arity+1 variables).
 fn insert_var(tbl: u32, arity: u8, pos: u8) -> u32 {
-  let block = 1u32 << pos;        // size of each block
-  let n = 1u32 << arity;          // number of entries in source table
+  let n_old = n_entries(arity);
+  let n_new = n_old << 1;
   let mut result: u32 = 0;
-  let mut src_bit = 0u32;
-  let mut dst_bit = 0u32;
-  while src_bit < n {
-    // Copy a block of `block` bits, then duplicate it
-    for _ in 0..block {
-      let bit_val = (tbl >> src_bit) & 1;
-      result |= bit_val << dst_bit;
-      result |= bit_val << (dst_bit + block);
-      src_bit += 1;
-      dst_bit += 1;
-    }
-    dst_bit += block; // skip past the duplicated block
+  for j in 0..n_new {
+    // Remove bit at position `pos` from entry index j to get original index.
+    let hi = (j >> (pos + 1)) << pos;
+    let lo = j & ((1 << pos) - 1);
+    let orig = hi | lo;
+    let old_bit = (tbl >> (n_old - 1 - orig)) & 1;
+    result |= old_bit << (n_new - 1 - j);
   }
   result
 }
 
-/// Expand a truth table's variable set to a target variable set.
+/// Expand a truth table's variable set to a target variable set (MSB-first).
 /// `src_vars` must be a subset of `dst_vars` (both sorted ascending).
-/// Returns the expanded truth table over `dst_vars`.
 fn expand_table(tbl: u32, src_vars: &[u32], dst_vars: &[u32]) -> u32 {
   let mut result = tbl;
   let mut current_arity = src_vars.len() as u8;
   let mut src_idx = 0usize;
   for (dst_pos, &dv) in dst_vars.iter().enumerate() {
     if src_idx < src_vars.len() && src_vars[src_idx] == dv {
-      src_idx += 1; // variable already present, skip
+      src_idx += 1;
     } else {
-      // insert don't-care at this position
       result = insert_var(result, current_arity, dst_pos as u8);
       current_arity += 1;
     }
@@ -78,13 +61,11 @@ fn expand_table(tbl: u32, src_vars: &[u32], dst_vars: &[u32]) -> u32 {
 
 /// Align two table NIDs to a common variable set.
 /// Returns None if the combined variable count exceeds 5.
-/// Otherwise returns (expanded_tbl_a, expanded_tbl_b, combined_vars).
 pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
   let (ar_a, vars_a) = a.vars();
   let (ar_b, vars_b) = b.vars();
   let va = &vars_a[..ar_a as usize];
   let vb = &vars_b[..ar_b as usize];
-  // Merge sorted variable lists
   let mut combined = Vec::with_capacity(5);
   let (mut ia, mut ib) = (0, 0);
   while ia < va.len() && ib < vb.len() {
@@ -102,54 +83,72 @@ pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
 
 // ---- constructing result table NIDs from raw truth tables ----
 
-/// Build a NID from a truth table and variable set, normalizing edge cases:
-/// - all-zero -> O, all-ones -> I
-/// - single-variable -> var NID or !var NID
-/// - otherwise -> table NID
+/// Build a NID from a truth table (MSB-first) and variable set, normalising:
+/// - all-zero → O,  all-ones → I
+/// - single-variable → var NID (or !var)
+/// - otherwise → table NID (with INV normalisation)
 pub fn make_table_nid(tbl: u32, vars: &[u32]) -> NID {
-  if vars.is_empty() { return if tbl & 1 == 0 { O } else { I }; }
-  // Strip degenerate variables then normalize.
+  if vars.is_empty() {
+    // arity 0: bit 0 = the single entry
+    return if tbl & 1 == 0 { O } else { I }; }
   let (tbl, vars) = strip_unused_vars(tbl, vars);
-  let arity = vars.len();
-  let mask = if arity >= 5 { 0xFFFFFFFFu32 } else { (1u32 << (1u32 << arity)) - 1 };
+  let arity = vars.len() as u8;
+  let mask = tbl_mask(arity);
   let effective = tbl & mask;
-  // constant?
   if effective == 0 { return O; }
   if effective == mask { return I; }
   // single variable?
   if arity == 1 {
     let v = VID::var(vars[0]);
-    if effective == 0b10u32 { return NID::from_vid(v); }
-    else { return !NID::from_vid(v); }
+    // MSB-first arity-1: identity = 0b01, negation = 0b10
+    return if effective == 0b01 { NID::from_vid(v) } else { !NID::from_vid(v) };
   }
-  // INV normalization: if bit 0 (LSB-first = all-zeros input) is set,
-  // store inverted table with INV flag.
-  if effective & 1 == 1 {
+  // INV normalisation: if f(0,0,…,0) = 1 (MSB is set), store ¬f and set INV.
+  let n = n_entries(arity);
+  if effective >> (n - 1) & 1 == 1 {
     let inv_tbl = !effective & mask;
-    let msb = reverse_bits(inv_tbl, arity as u8);
-    return !NID::fun_with_vars(&vars, msb).to_nid();
+    return !NID::fun_with_vars(&vars, inv_tbl).to_nid();
   }
-  // Convert LSB-first → MSB-first for NID storage
-  let msb = reverse_bits(effective, arity as u8);
-  NID::fun_with_vars(&vars, msb).to_nid()
+  NID::fun_with_vars(&vars, effective).to_nid()
 }
 
-/// Check if variable at position `pos` in a truth table of `arity` variables is unused.
-/// A variable is unused if setting it to 0 or 1 gives the same result.
+/// Convert a NidFun (from `Fun::when()`) + remaining variable set to NID.
+pub fn nidfun_to_nid(f: &NidFun, vars: &[u32]) -> NID {
+  make_table_nid(f.tbl(), vars)
+}
+
+// ---- degenerate variable detection (MSB-first) ----
+
+/// Is variable at position `pos` unused in a truth table of `arity` variables?
 fn var_is_unused(tbl: u32, arity: u8, pos: u8) -> bool {
-  let block = 1u32 << pos;
-  // Mask that selects every other group of `block` bits
-  let mut lo_mask: u32 = 0;
-  let n = 1u32 << arity;
-  let mut i = 0u32;
-  while i < n {
-    // bits i..i+block have the variable = 0
-    for j in 0..block { lo_mask |= 1 << (i + j); }
-    i += 2 * block;
+  let n = n_entries(arity);
+  // For every pair of entries (i, i ^ (1<<pos)), check that they agree.
+  // We only need to check entries where bit `pos` is 0.
+  for i in 0..n {
+    if (i >> pos) & 1 == 0 {
+      let j = i | (1 << pos);
+      let vi = (tbl >> (n - 1 - i)) & 1;
+      let vj = (tbl >> (n - 1 - j)) & 1;
+      if vi != vj { return false; }
+    }
   }
-  let lo_val = tbl & lo_mask;
-  let hi_val = (tbl >> block) & lo_mask;
-  lo_val == hi_val
+  true
+}
+
+/// Remove variable at position `pos` from a truth table (MSB-first).
+fn remove_var(tbl: u32, arity: u8, pos: u8) -> u32 {
+  let n_old = n_entries(arity);
+  let n_new = n_old >> 1;
+  let mut result: u32 = 0;
+  let mut dst = 0u32;
+  for i in 0..n_old {
+    if (i >> pos) & 1 == 0 {
+      let bit = (tbl >> (n_old - 1 - i)) & 1;
+      result |= bit << (n_new - 1 - dst);
+      dst += 1;
+    }
+  }
+  result
 }
 
 /// Strip unused variables from a truth table, returning the reduced table and variable list.
@@ -158,24 +157,8 @@ fn strip_unused_vars(mut tbl: u32, vars: &[u32]) -> (u32, Vec<u32>) {
   let mut pos = 0u8;
   while (pos as usize) < remaining.len() {
     if var_is_unused(tbl, remaining.len() as u8, pos) {
-      // Remove variable at this position: collapse the table
-      let block = 1u32 << pos;
-      let arity = remaining.len() as u8;
-      let n = 1u32 << arity;
-      let mut new_tbl: u32 = 0;
-      let mut src = 0u32;
-      let mut dst = 0u32;
-      while src < n {
-        for _ in 0..block {
-          new_tbl |= ((tbl >> src) & 1) << dst;
-          src += 1;
-          dst += 1;
-        }
-        src += block; // skip the duplicate block
-      }
-      tbl = new_tbl;
+      tbl = remove_var(tbl, remaining.len() as u8, pos);
       remaining.remove(pos as usize);
-      // Don't increment pos: the next variable shifted into this position
     } else {
       pos += 1;
     }
@@ -183,45 +166,32 @@ fn strip_unused_vars(mut tbl: u32, vars: &[u32]) -> (u32, Vec<u32>) {
   (tbl, remaining)
 }
 
-/// Convert a NidFun (from a Fun::when() result) + remaining variable set to the correct NID.
-/// The NidFun stores its table in MSB-first; convert to LSB-first for make_table_nid.
-pub fn nidfun_to_nid(f: &NidFun, vars: &[u32]) -> NID {
-  let lsb_tbl = reverse_bits(f.tbl(), vars.len() as u8);
-  make_table_nid(lsb_tbl, vars)
-}
-
 // ---- promoting consts/vars to truth tables for alignment ----
 
-/// Get the truth table and variable set for any "small" NID
-/// (constant, variable, or table NID). Returns None for BDD nodes.
+/// Get the truth table (MSB-first) and variable set for any "small" NID.
+/// Returns None for BDD nodes.
 fn nid_to_table(n: NID) -> Option<(u32, Vec<u32>)> {
   if n.is_const() {
     Some((if n == I { 0xFFFFFFFF } else { 0 }, vec![]))
   } else if n.is_var() {
     let vi = n.vid().var_ix() as u32;
-    let tbl = if n.is_inv() { 0b01u32 } else { 0b10u32 };
+    // MSB-first arity-1: identity = 0b01
+    let tbl = if n.is_inv() { 0b10u32 } else { 0b01u32 };
     Some((tbl, vec![vi]))
   } else if n.is_fun() {
     let f = n.to_fun().unwrap();
     let (ar, vars) = f.vars();
-    let mut tbl = reverse_bits(f.tbl(), ar); // MSB→LSB conversion
-    if n.is_inv() {
-      let mask = if ar >= 5 { 0xFFFFFFFFu32 } else { (1u32 << (1u32 << ar)) - 1 };
-      tbl ^= mask;
-    }
+    let mut tbl = f.tbl();  // already MSB-first
+    if n.is_inv() { tbl ^= tbl_mask(ar); }
     Some((tbl, vars[..ar as usize].to_vec()))
   } else {
     None
   }
 }
 
-/// Try to align two NIDs (each may be const, var, or table) to a common variable set.
-/// Returns None if either is a BDD node or combined vars > 5.
-fn align_nids(a: NID, b: NID) -> Option<(u32, u32, Vec<u32>)> {
-  let (ta, va) = nid_to_table(a)?;
-  let (tb, vb) = nid_to_table(b)?;
-  // Merge
-  let mut combined = Vec::with_capacity(5);
+/// Merge two sorted variable lists.
+fn merge_vars(va: &[u32], vb: &[u32]) -> Vec<u32> {
+  let mut combined = Vec::with_capacity(va.len() + vb.len());
   let (mut ia, mut ib) = (0, 0);
   while ia < va.len() && ib < vb.len() {
     if va[ia] < vb[ib] { combined.push(va[ia]); ia += 1; }
@@ -230,46 +200,37 @@ fn align_nids(a: NID, b: NID) -> Option<(u32, u32, Vec<u32>)> {
   }
   while ia < va.len() { combined.push(va[ia]); ia += 1; }
   while ib < vb.len() { combined.push(vb[ib]); ib += 1; }
-  if combined.len() > 5 { return None; }
-  let ea = expand_table(ta, &va, &combined);
-  let eb = expand_table(tb, &vb, &combined);
-  Some((ea, eb, combined))
+  combined
 }
 
-/// Try to align three NIDs to a common variable set.
+/// Align two NIDs to a common variable set. Returns None if either is a BDD
+/// node or combined vars > 5.
+fn align_nids(a: NID, b: NID) -> Option<(u32, u32, Vec<u32>)> {
+  let (ta, va) = nid_to_table(a)?;
+  let (tb, vb) = nid_to_table(b)?;
+  let combined = merge_vars(&va, &vb);
+  if combined.len() > 5 { return None; }
+  Some((expand_table(ta, &va, &combined),
+        expand_table(tb, &vb, &combined),
+        combined))
+}
+
+/// Align three NIDs to a common variable set.
 fn align_three(i: NID, t: NID, e: NID) -> Option<(u32, u32, u32, Vec<u32>)> {
   let (ti, vi) = nid_to_table(i)?;
   let (tt, vt) = nid_to_table(t)?;
   let (te, ve) = nid_to_table(e)?;
-  // Merge three sorted lists
-  let mut combined = Vec::with_capacity(5);
-  let (mut a, mut b, mut c) = (0, 0, 0);
-  loop {
-    let va = if a < vi.len() { Some(vi[a]) } else { None };
-    let vb = if b < vt.len() { Some(vt[b]) } else { None };
-    let vc = if c < ve.len() { Some(ve[c]) } else { None };
-    match (va, vb, vc) {
-      (None, None, None) => break,
-      _ => {
-        let min = [va, vb, vc].iter().copied().flatten().min().unwrap();
-        combined.push(min);
-        if va == Some(min) { a += 1; }
-        if vb == Some(min) { b += 1; }
-        if vc == Some(min) { c += 1; }
-      }
-    }
-  }
+  let combined = merge_vars(&merge_vars(&vi, &vt), &ve);
   if combined.len() > 5 { return None; }
-  let ei = expand_table(ti, &vi, &combined);
-  let et = expand_table(tt, &vt, &combined);
-  let ee = expand_table(te, &ve, &combined);
-  Some((ei, et, ee, combined))
+  Some((expand_table(ti, &vi, &combined),
+        expand_table(tt, &vt, &combined),
+        expand_table(te, &ve, &combined),
+        combined))
 }
 
 // ---- table-level operations ----
 
 /// Compute AND of two NIDs entirely via truth tables.
-/// Returns None if either operand is a BDD node or combined vars > 5.
 pub fn table_and(x: NID, y: NID) -> Option<NID> {
   let (tx, ty, vars) = align_nids(x, y)?;
   Some(make_table_nid(tx & ty, &vars))
@@ -313,11 +274,7 @@ impl<T: crate::base::Base> crate::base::Base for TableBase<T> {
           new_vars.remove(pos as usize);
           let result = nidfun_to_nid(&reduced, &new_vars);
           return if n.is_inv() { !result } else { result };
-        } else {
-          return n; // variable not in set, no change
-        }
-      }
-    }
+        } else { return n; }}}
     self.base.when_hi(v, n)
   }
 
@@ -331,11 +288,7 @@ impl<T: crate::base::Base> crate::base::Base for TableBase<T> {
           new_vars.remove(pos as usize);
           let result = nidfun_to_nid(&reduced, &new_vars);
           return if n.is_inv() { !result } else { result };
-        } else {
-          return n;
-        }
-      }
-    }
+        } else { return n; }}}
     self.base.when_lo(v, n)
   }
 
@@ -366,18 +319,17 @@ mod tests {
   use super::*;
   use crate::nid::named::*;
 
-  /// Evaluate a NID on a specific input assignment (for testing).
-  /// vars_vals: list of (var_index, bool) pairs.
+  /// Evaluate a NID on a specific input assignment (MSB-first convention).
   fn eval_nid(n: NID, vars_vals: &[(u32, bool)]) -> bool {
     if let Some((tbl, vars)) = nid_to_table(n) {
-      // tbl is LSB-first internally
-      let mut row = 0usize;
+      let nn = n_entries(vars.len() as u8);
+      let mut row = 0u32;
       for (pos, &v) in vars.iter().enumerate() {
         for &(vi, val) in vars_vals {
           if vi == v && val { row |= 1 << pos; }
         }
       }
-      (tbl >> row) & 1 == 1
+      (tbl >> (nn - 1 - row)) & 1 == 1
     } else {
       panic!("eval_nid: not a table/const/var NID");
     }
@@ -385,38 +337,38 @@ mod tests {
 
   #[test]
   fn test_insert_var() {
-    // f(a) = a (truth table 0b10) -> insert don't-care at position 0
-    // Position 0 is fastest-alternating. Original var shifts to position 1.
-    // New table: bit0(new=0,a=0)=0, bit1(new=1,a=0)=0, bit2(new=0,a=1)=1, bit3(new=1,a=1)=1
-    assert_eq!(insert_var(0b10, 1, 0), 0b1100);
-    // insert don't-care at position 1 (slower). Original var stays at position 0.
-    // bit0(a=0,new=0)=0, bit1(a=1,new=0)=1, bit2(a=0,new=1)=0, bit3(a=1,new=1)=1
-    assert_eq!(insert_var(0b10, 1, 1), 0b1010);
+    // f(a) = identity.  MSB-first arity 1: 0b01
+    // Insert don't-care at position 0 → arity 2, a moves to position 1.
+    // Signal for position 1 is 0b0011.
+    assert_eq!(insert_var(0b01, 1, 0), 0b0011);
+    // Insert don't-care at position 1 → a stays at position 0.
+    // Signal for position 0 is 0b0101.
+    assert_eq!(insert_var(0b01, 1, 1), 0b0101);
   }
 
   #[test]
   fn test_expand_table() {
-    // f(x1) = x1 (table 0b10) with vars [1]
-    // expand to [0, 1]: insert x0 at position 0
-    let expanded = expand_table(0b10, &[1], &[0, 1]);
-    // Result should be x1 over {x0, x1}: 0b1100
-    assert_eq!(expanded, 0b1100);
+    // f(x1) = x1, identity = 0b01 (MSB-first arity 1)
+    // Expand to {x0, x1}: insert x0 at position 0.
+    // x1 signal over {x0,x1} is 0b0011.
+    assert_eq!(expand_table(0b01, &[1], &[0, 1]), 0b0011);
 
-    // f(x0) = x0 (table 0b10) with vars [0]
-    // expand to [0, 1]: insert x1 at position 1
-    let expanded2 = expand_table(0b10, &[0], &[0, 1]);
-    // Result should be x0 over {x0, x1}: 0b1010
-    assert_eq!(expanded2, 0b1010);
+    // f(x0) = x0, identity = 0b01
+    // Expand to {x0, x1}: insert x1 at position 1.
+    // x0 signal over {x0,x1} is 0b0101.
+    assert_eq!(expand_table(0b01, &[0], &[0, 1]), 0b0101);
   }
 
   #[test]
   fn test_table_and_two_vars() {
     let result = table_and(x0, x1).unwrap();
-    // Verify AND truth table: f(a,b) = a AND b
     assert!(!eval_nid(result, &[(0,false),(1,false)]));
     assert!(!eval_nid(result, &[(0,true),(1,false)]));
     assert!(!eval_nid(result, &[(0,false),(1,true)]));
     assert!( eval_nid(result, &[(0,true),(1,true)]));
+    // also check the stored table directly (MSB-first AND = 0b0001)
+    let f = result.raw().to_fun().unwrap();
+    assert_eq!(f.tbl(), 0b0001);
   }
 
   #[test]
@@ -435,6 +387,9 @@ mod tests {
     assert!( eval_nid(result, &[(0,true),(1,false)]));
     assert!( eval_nid(result, &[(0,false),(1,true)]));
     assert!(!eval_nid(result, &[(0,true),(1,true)]));
+    // MSB-first XOR = 0b0110
+    let f = result.raw().to_fun().unwrap();
+    assert_eq!(f.tbl(), 0b0110);
   }
 
   #[test]
@@ -469,7 +424,6 @@ mod tests {
   #[test]
   fn test_table_ite() {
     let result = table_ite(x0, x1, x2).unwrap();
-    // if x0 then x1 else x2
     assert!( eval_nid(result, &[(0,true),(1,true),(2,false)]));  // take x1=T
     assert!(!eval_nid(result, &[(0,true),(1,false),(2,true)]));  // take x1=F
     assert!( eval_nid(result, &[(0,false),(1,false),(2,true)])); // take x2=T
@@ -478,8 +432,8 @@ mod tests {
 
   #[test]
   fn test_table_and_overlapping_vars() {
-    // x1 OR x3 (MSB-first: 0b0111) AND x2 AND x3 (MSB-first: 0b0001)
-    // Result simplifies to x2 AND x3
+    // OR(x1,x3) = 0b0111, AND(x2,x3) = 0b0001  (MSB-first)
+    // result simplifies to AND(x2,x3), since x1 drops out
     let f = NID::fun_with_vars(&[1, 3], 0b0111).to_nid();
     let g = NID::fun_with_vars(&[2, 3], 0b0001).to_nid();
     let result = table_and(f, g).unwrap();
@@ -490,58 +444,53 @@ mod tests {
 
   #[test]
   fn test_make_table_nid_degenerate() {
-    // all-zero -> O
     assert_eq!(make_table_nid(0, &[0, 1]), O);
-    // all-ones -> I
     assert_eq!(make_table_nid(0b1111, &[0, 1]), I);
-    // single var identity
-    assert_eq!(make_table_nid(0b10, &[3]), NID::var(3));
-    // single var inverted
-    assert_eq!(make_table_nid(0b01, &[3]), !NID::var(3));
+    // MSB-first arity-1 identity = 0b01
+    assert_eq!(make_table_nid(0b01, &[3]), NID::var(3));
+    assert_eq!(make_table_nid(0b10, &[3]), !NID::var(3));
   }
 
   #[test]
   fn test_strip_unused_vars() {
-    // x0 AND x1 = 0b1000. Table truly depends on both -> no change.
-    let (tbl, vars) = strip_unused_vars(0b1000, &[0, 1]);
+    // AND = 0b0001 over {x0,x1}: depends on both → no change
+    let (tbl, vars) = strip_unused_vars(0b0001, &[0, 1]);
     assert_eq!(vars, vec![0, 1]);
-    assert_eq!(tbl, 0b1000);
+    assert_eq!(tbl, 0b0001);
 
-    // Table 0b1010 over {x0, x1} = just x0 (doesn't depend on x1)
-    let (tbl, vars) = strip_unused_vars(0b1010, &[0, 1]);
+    // x0 signal = 0b0101 over {x0,x1}: doesn't depend on x1
+    let (tbl, vars) = strip_unused_vars(0b0101, &[0, 1]);
     assert_eq!(vars, vec![0]);
-    assert_eq!(tbl, 0b10); // reduced to 1-var table for x0
+    assert_eq!(tbl, 0b01);
 
-    // Table 0b1100 over {x0, x1} = just x1 (doesn't depend on x0)
-    let (tbl, vars) = strip_unused_vars(0b1100, &[0, 1]);
+    // x1 signal = 0b0011 over {x0,x1}: doesn't depend on x0
+    let (tbl, vars) = strip_unused_vars(0b0011, &[0, 1]);
     assert_eq!(vars, vec![1]);
-    assert_eq!(tbl, 0b10);
+    assert_eq!(tbl, 0b01);
   }
 
   #[test]
   fn test_make_table_nid_removes_unused() {
-    // make_table_nid should detect that 0b1010 over {x0, x1} only depends on x0
-    let n = make_table_nid(0b1010, &[0, 1]);
+    // x0 signal = 0b0101 over {x0,x1}: only depends on x0
+    let n = make_table_nid(0b0101, &[0, 1]);
     assert_eq!(n, x0);
   }
 
   #[test]
   fn test_inv_normalization() {
-    // LSB-first 0b0111 over {x0, x1} has bit 0 = 1, so it should be stored inverted.
-    // 0b0111 is NAND in LSB-first. Inverted = AND = 0b1000 LSB-first.
-    let n = make_table_nid(0b0111, &[0, 1]);
-    assert!(n.is_inv(), "should be inverted");
-    // The underlying function is AND: f(0,0)=0,f(1,0)=0,f(0,1)=0,f(1,1)=1
-    // NAND = !AND: f(0,0)=1,f(1,0)=1,f(0,1)=1,f(1,1)=0
-    assert!( eval_nid(n, &[(0,false),(1,false)])); // NAND(0,0)=1
-    assert!(!eval_nid(n, &[(0,true),(1,true)]));   // NAND(1,1)=0
+    // OR(x0,x1) = 0b0111. f(0,0)=0 (MSB=0), so no INV needed.
+    let n_or = make_table_nid(0b0111, &[0, 1]);
+    assert!(!n_or.is_inv());
+    // NAND(x0,x1) = 0b1110.  f(0,0)=1 (MSB=1), so store ¬f = AND = 0b0001 with INV.
+    let n_nand = make_table_nid(0b1110, &[0, 1]);
+    assert!(n_nand.is_inv(), "NAND should be stored inverted");
+    let f = n_nand.raw().to_fun().unwrap();
+    assert_eq!(f.tbl(), 0b0001, "underlying function should be AND");
   }
 
   #[test]
   fn test_table_xor_degenerate_result() {
-    // x0 XOR x0 = O (via table operation)
     assert_eq!(table_xor(x0, x0).unwrap(), O);
-    // (x0 AND x1) XOR (x0 AND x1) = O
     let a = table_and(x0, x1).unwrap();
     assert_eq!(table_xor(a, a).unwrap(), O);
   }

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -1,0 +1,404 @@
+//! Table NID operations and the `TableBase` decorator.
+//!
+//! Provides truth table alignment (expanding tables to a common variable set),
+//! bitwise operations on table NIDs, and a `TableBase<T>` decorator that wraps
+//! any `Base` to automatically collapse small subgraphs into table NIDs.
+
+use crate::nid::{NID, NidFun, I, O};
+use crate::vid::VID;
+use crate::Fun;
+
+// ---- truth table alignment ----
+
+/// Insert a "don't care" variable at position `pos` in a truth table of `arity` variables.
+/// The new variable does not affect the output: each block of 2^pos entries is duplicated.
+/// Returns the expanded table (arity+1 variables).
+fn insert_var(tbl: u32, arity: u8, pos: u8) -> u32 {
+  let block = 1u32 << pos;        // size of each block
+  let n = 1u32 << arity;          // number of entries in source table
+  let mut result: u32 = 0;
+  let mut src_bit = 0u32;
+  let mut dst_bit = 0u32;
+  while src_bit < n {
+    // Copy a block of `block` bits, then duplicate it
+    for _ in 0..block {
+      let bit_val = (tbl >> src_bit) & 1;
+      result |= bit_val << dst_bit;
+      result |= bit_val << (dst_bit + block);
+      src_bit += 1;
+      dst_bit += 1;
+    }
+    dst_bit += block; // skip past the duplicated block
+  }
+  result
+}
+
+/// Expand a truth table's variable set to a target variable set.
+/// `src_vars` must be a subset of `dst_vars` (both sorted ascending).
+/// Returns the expanded truth table over `dst_vars`.
+fn expand_table(tbl: u32, src_vars: &[u32], dst_vars: &[u32]) -> u32 {
+  let mut result = tbl;
+  let mut current_arity = src_vars.len() as u8;
+  let mut src_idx = 0usize;
+  for (dst_pos, &dv) in dst_vars.iter().enumerate() {
+    if src_idx < src_vars.len() && src_vars[src_idx] == dv {
+      src_idx += 1; // variable already present, skip
+    } else {
+      // insert don't-care at this position
+      result = insert_var(result, current_arity, dst_pos as u8);
+      current_arity += 1;
+    }
+  }
+  result
+}
+
+/// Align two table NIDs to a common variable set.
+/// Returns None if the combined variable count exceeds 5.
+/// Otherwise returns (expanded_tbl_a, expanded_tbl_b, combined_vars).
+pub fn align_tables(a: &NidFun, b: &NidFun) -> Option<(u32, u32, Vec<u32>)> {
+  let (ar_a, vars_a) = a.vars();
+  let (ar_b, vars_b) = b.vars();
+  let va = &vars_a[..ar_a as usize];
+  let vb = &vars_b[..ar_b as usize];
+  // Merge sorted variable lists
+  let mut combined = Vec::with_capacity(5);
+  let (mut ia, mut ib) = (0, 0);
+  while ia < va.len() && ib < vb.len() {
+    if va[ia] < vb[ib] { combined.push(va[ia]); ia += 1; }
+    else if va[ia] > vb[ib] { combined.push(vb[ib]); ib += 1; }
+    else { combined.push(va[ia]); ia += 1; ib += 1; }
+  }
+  while ia < va.len() { combined.push(va[ia]); ia += 1; }
+  while ib < vb.len() { combined.push(vb[ib]); ib += 1; }
+  if combined.len() > 5 { return None; }
+  let ta = expand_table(a.tbl(), va, &combined);
+  let tb = expand_table(b.tbl(), vb, &combined);
+  Some((ta, tb, combined))
+}
+
+// ---- constructing result table NIDs from raw truth tables ----
+
+/// Build a NID from a truth table and variable set, normalizing edge cases:
+/// - all-zero -> O, all-ones -> I
+/// - single-variable -> var NID or !var NID
+/// - otherwise -> table NID
+pub fn make_table_nid(tbl: u32, vars: &[u32]) -> NID {
+  let arity = vars.len();
+  let mask = if arity >= 5 { 0xFFFFFFFFu32 } else { (1u32 << (1u32 << arity)) - 1 };
+  let effective = tbl & mask;
+  // constant?
+  if effective == 0 { return O; }
+  if effective == mask { return I; }
+  // single variable?
+  if arity == 1 {
+    let v = VID::var(vars[0]);
+    let var_pattern = 0b10u32; // truth table for identity: f(x)=x
+    if effective == var_pattern { return NID::from_vid(v); }
+    else { return !NID::from_vid(v); }
+  }
+  // general table NID
+  NID::fun_with_vars(vars, effective).to_nid()
+}
+
+/// Convert a NidFun (from a Fun::when() result) + remaining variable set to the correct NID.
+/// Handles arity 0 -> const, arity 1 -> variable, arity 2+ -> table NID.
+pub fn nidfun_to_nid(f: &NidFun, vars: &[u32]) -> NID {
+  make_table_nid(f.tbl(), vars)
+}
+
+// ---- promoting consts/vars to truth tables for alignment ----
+
+/// Get the truth table and variable set for any "small" NID
+/// (constant, variable, or table NID). Returns None for BDD nodes.
+fn nid_to_table(n: NID) -> Option<(u32, Vec<u32>)> {
+  if n.is_const() {
+    Some((if n == I { 0xFFFFFFFF } else { 0 }, vec![]))
+  } else if n.is_var() {
+    let vi = n.vid().var_ix() as u32;
+    let tbl = if n.is_inv() { 0b01u32 } else { 0b10u32 };
+    Some((tbl, vec![vi]))
+  } else if n.is_fun() {
+    let f = n.to_fun().unwrap();
+    let (ar, vars) = f.vars();
+    let mut tbl = f.tbl();
+    if n.is_inv() {
+      let mask = if ar >= 5 { 0xFFFFFFFFu32 } else { (1u32 << (1u32 << ar)) - 1 };
+      tbl ^= mask;
+    }
+    Some((tbl, vars[..ar as usize].to_vec()))
+  } else {
+    None
+  }
+}
+
+/// Try to align two NIDs (each may be const, var, or table) to a common variable set.
+/// Returns None if either is a BDD node or combined vars > 5.
+fn align_nids(a: NID, b: NID) -> Option<(u32, u32, Vec<u32>)> {
+  let (ta, va) = nid_to_table(a)?;
+  let (tb, vb) = nid_to_table(b)?;
+  // Merge
+  let mut combined = Vec::with_capacity(5);
+  let (mut ia, mut ib) = (0, 0);
+  while ia < va.len() && ib < vb.len() {
+    if va[ia] < vb[ib] { combined.push(va[ia]); ia += 1; }
+    else if va[ia] > vb[ib] { combined.push(vb[ib]); ib += 1; }
+    else { combined.push(va[ia]); ia += 1; ib += 1; }
+  }
+  while ia < va.len() { combined.push(va[ia]); ia += 1; }
+  while ib < vb.len() { combined.push(vb[ib]); ib += 1; }
+  if combined.len() > 5 { return None; }
+  let ea = expand_table(ta, &va, &combined);
+  let eb = expand_table(tb, &vb, &combined);
+  Some((ea, eb, combined))
+}
+
+/// Try to align three NIDs to a common variable set.
+fn align_three(i: NID, t: NID, e: NID) -> Option<(u32, u32, u32, Vec<u32>)> {
+  let (ti, vi) = nid_to_table(i)?;
+  let (tt, vt) = nid_to_table(t)?;
+  let (te, ve) = nid_to_table(e)?;
+  // Merge three sorted lists
+  let mut combined = Vec::with_capacity(5);
+  let (mut a, mut b, mut c) = (0, 0, 0);
+  loop {
+    let va = if a < vi.len() { Some(vi[a]) } else { None };
+    let vb = if b < vt.len() { Some(vt[b]) } else { None };
+    let vc = if c < ve.len() { Some(ve[c]) } else { None };
+    match (va, vb, vc) {
+      (None, None, None) => break,
+      _ => {
+        let min = [va, vb, vc].iter().copied().flatten().min().unwrap();
+        combined.push(min);
+        if va == Some(min) { a += 1; }
+        if vb == Some(min) { b += 1; }
+        if vc == Some(min) { c += 1; }
+      }
+    }
+  }
+  if combined.len() > 5 { return None; }
+  let ei = expand_table(ti, &vi, &combined);
+  let et = expand_table(tt, &vt, &combined);
+  let ee = expand_table(te, &ve, &combined);
+  Some((ei, et, ee, combined))
+}
+
+// ---- table-level operations ----
+
+/// Compute AND of two NIDs entirely via truth tables.
+/// Returns None if either operand is a BDD node or combined vars > 5.
+pub fn table_and(x: NID, y: NID) -> Option<NID> {
+  let (tx, ty, vars) = align_nids(x, y)?;
+  Some(make_table_nid(tx & ty, &vars))
+}
+
+/// Compute XOR of two NIDs entirely via truth tables.
+pub fn table_xor(x: NID, y: NID) -> Option<NID> {
+  let (tx, ty, vars) = align_nids(x, y)?;
+  Some(make_table_nid(tx ^ ty, &vars))
+}
+
+/// Compute OR of two NIDs entirely via truth tables.
+pub fn table_or(x: NID, y: NID) -> Option<NID> {
+  let (tx, ty, vars) = align_nids(x, y)?;
+  Some(make_table_nid(tx | ty, &vars))
+}
+
+/// Compute ITE(i, t, e) entirely via truth tables.
+pub fn table_ite(i: NID, t: NID, e: NID) -> Option<NID> {
+  let (ti, tt, te, vars) = align_three(i, t, e)?;
+  Some(make_table_nid((ti & tt) | (!ti & te), &vars))
+}
+
+
+// ---- TableBase decorator ----
+
+/// A decorator around any `Base` that automatically computes operations
+/// on table NIDs (and constants/variables) without entering the BDD pipeline.
+pub struct TableBase<T: crate::base::Base> { pub base: T }
+
+impl<T: crate::base::Base> crate::base::Base for TableBase<T> {
+  crate::inherit![new, def, tag, get, sub, dot];
+
+  fn when_hi(&mut self, v:VID, n:NID)->NID {
+    if n.is_fun() {
+      if let Some(f) = n.to_fun() {
+        if let Some(pos) = f.var_position(v) {
+          let reduced = f.when(pos, true);
+          let (ar, vs) = f.vars();
+          let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
+          new_vars.remove(pos as usize);
+          let result = make_table_nid(reduced.tbl(), &new_vars);
+          return if n.is_inv() { !result } else { result };
+        } else {
+          return n; // variable not in set, no change
+        }
+      }
+    }
+    self.base.when_hi(v, n)
+  }
+
+  fn when_lo(&mut self, v:VID, n:NID)->NID {
+    if n.is_fun() {
+      if let Some(f) = n.to_fun() {
+        if let Some(pos) = f.var_position(v) {
+          let reduced = f.when(pos, false);
+          let (ar, vs) = f.vars();
+          let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
+          new_vars.remove(pos as usize);
+          let result = make_table_nid(reduced.tbl(), &new_vars);
+          return if n.is_inv() { !result } else { result };
+        } else {
+          return n;
+        }
+      }
+    }
+    self.base.when_lo(v, n)
+  }
+
+  fn and(&mut self, x:NID, y:NID)->NID {
+    if let Some(r) = table_and(x, y) { return r; }
+    self.base.and(x, y)
+  }
+
+  fn xor(&mut self, x:NID, y:NID)->NID {
+    if let Some(r) = table_xor(x, y) { return r; }
+    self.base.xor(x, y)
+  }
+
+  fn or(&mut self, x:NID, y:NID)->NID {
+    if let Some(r) = table_or(x, y) { return r; }
+    self.base.or(x, y)
+  }
+
+  fn ite(&mut self, i:NID, t:NID, e:NID)->NID {
+    if let Some(r) = table_ite(i, t, e) { return r; }
+    self.base.ite(i, t, e)
+  }
+}
+
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::nid::named::*;
+
+  #[test]
+  fn test_insert_var() {
+    // f(a) = a (truth table 0b10) -> insert don't-care at position 0
+    // Position 0 is fastest-alternating. Original var shifts to position 1.
+    // New table: bit0(new=0,a=0)=0, bit1(new=1,a=0)=0, bit2(new=0,a=1)=1, bit3(new=1,a=1)=1
+    assert_eq!(insert_var(0b10, 1, 0), 0b1100);
+    // insert don't-care at position 1 (slower). Original var stays at position 0.
+    // bit0(a=0,new=0)=0, bit1(a=1,new=0)=1, bit2(a=0,new=1)=0, bit3(a=1,new=1)=1
+    assert_eq!(insert_var(0b10, 1, 1), 0b1010);
+  }
+
+  #[test]
+  fn test_expand_table() {
+    // f(x1) = x1 (table 0b10) with vars [1]
+    // expand to [0, 1]: insert x0 at position 0
+    let expanded = expand_table(0b10, &[1], &[0, 1]);
+    // Result should be x1 over {x0, x1}: 0b1100
+    assert_eq!(expanded, 0b1100);
+
+    // f(x0) = x0 (table 0b10) with vars [0]
+    // expand to [0, 1]: insert x1 at position 1
+    let expanded2 = expand_table(0b10, &[0], &[0, 1]);
+    // Result should be x0 over {x0, x1}: 0b1010
+    assert_eq!(expanded2, 0b1010);
+  }
+
+  #[test]
+  fn test_table_and_two_vars() {
+    // x0 AND x1: both are simple variables
+    let result = table_and(x0, x1).unwrap();
+    assert!(result.is_fun());
+    let f = result.to_fun().unwrap();
+    assert_eq!(f.arity(), 2);
+    // AND truth table: 0b1000 (row order: 00->0, 01->0, 10->0, 11->1)
+    assert_eq!(f.tbl(), 0b1000);
+  }
+
+  #[test]
+  fn test_table_or_two_vars() {
+    let result = table_or(x0, x1).unwrap();
+    let f = result.to_fun().unwrap();
+    assert_eq!(f.arity(), 2);
+    assert_eq!(f.tbl(), 0b1110);
+  }
+
+  #[test]
+  fn test_table_xor_two_vars() {
+    let result = table_xor(x0, x1).unwrap();
+    let f = result.to_fun().unwrap();
+    assert_eq!(f.arity(), 2);
+    assert_eq!(f.tbl(), 0b0110);
+  }
+
+  #[test]
+  fn test_table_and_with_const() {
+    assert_eq!(table_and(x0, I).unwrap(), x0);
+    assert_eq!(table_and(x0, O).unwrap(), O);
+    assert_eq!(table_and(I, x1).unwrap(), x1);
+  }
+
+  #[test]
+  fn test_table_xor_same_var() {
+    assert_eq!(table_xor(x0, x0).unwrap(), O);
+  }
+
+  #[test]
+  fn test_table_and_disjoint_vars() {
+    // (x0 AND x1) AND (x2 AND x3) -> should produce a 4-variable table
+    let a01 = table_and(x0, x1).unwrap();
+    let a23 = table_and(x2, x3).unwrap();
+    let result = table_and(a01, a23).unwrap();
+    let f = result.to_fun().unwrap();
+    assert_eq!(f.arity(), 4);
+    let (_, vs) = f.vars();
+    assert_eq!(&vs[..4], &[0, 1, 2, 3]);
+  }
+
+  #[test]
+  fn test_table_exceeds_5_vars() {
+    // Create functions on 3 disjoint vars each -> combined = 6 > 5
+    let a = table_and(x0, table_and(x1, x2).unwrap()).unwrap();
+    let b = table_and(x3, table_and(x4, NID::var(5)).unwrap()).unwrap();
+    assert!(table_and(a, b).is_none(), "should fail: 6 vars > 5");
+  }
+
+  #[test]
+  fn test_table_ite() {
+    // ite(x0, x1, x2) = if x0 then x1 else x2
+    // Signals: x0=0xAA, x1=0xCC, x2=0xF0 (for 3-var 8-bit table)
+    // (x0 & x1) | (~x0 & x2) = 0x88 | 0x50 = 0xD8 = 0b11011000
+    let result = table_ite(x0, x1, x2).unwrap();
+    let f = result.to_fun().unwrap();
+    assert_eq!(f.arity(), 3);
+    assert_eq!(f.tbl(), 0b11011000);
+  }
+
+  #[test]
+  fn test_table_and_overlapping_vars() {
+    // f(x1, x3) AND g(x2, x3) -> combined {x1, x2, x3}, 3 vars
+    let f = NID::fun_with_vars(&[1, 3], 0b1110).to_nid(); // x1 OR x3
+    let g = NID::fun_with_vars(&[2, 3], 0b1000).to_nid(); // x2 AND x3
+    let result = table_and(f, g).unwrap();
+    let rf = result.to_fun().unwrap();
+    assert_eq!(rf.arity(), 3);
+    let (_, vs) = rf.vars();
+    assert_eq!(&vs[..3], &[1, 2, 3]);
+  }
+
+  #[test]
+  fn test_make_table_nid_degenerate() {
+    // all-zero -> O
+    assert_eq!(make_table_nid(0, &[0, 1]), O);
+    // all-ones -> I
+    assert_eq!(make_table_nid(0b1111, &[0, 1]), I);
+    // single var identity
+    assert_eq!(make_table_nid(0b10, &[3]), NID::var(3));
+    // single var inverted
+    assert_eq!(make_table_nid(0b01, &[3]), !NID::var(3));
+  }
+}

--- a/src/vhl.rs
+++ b/src/vhl.rs
@@ -124,8 +124,20 @@ impl VhlBase {
 
   #[inline] pub fn tup(&self, n:NID)-> (NID, NID) {
     use crate::nid::{I,O};
+    use crate::Fun;
     if n.is_const() { if n==I { (I, O) } else { (O, I) } }
     else if n.is_vid() { if n.is_inv() { (O, I) } else { (I, O) }}
+    else if n.is_fun() {
+      let f = n.to_fun().unwrap();
+      let (ar, vs) = f.vars();
+      let top_pos = ar - 1; // position of top (highest) variable
+      let hi_fun = f.when(top_pos, true);
+      let lo_fun = f.when(top_pos, false);
+      let mut new_vars: Vec<u32> = vs[..ar as usize].to_vec();
+      new_vars.pop(); // remove top variable
+      let hi = crate::tbl::nidfun_to_nid(&hi_fun, &new_vars);
+      let lo = crate::tbl::nidfun_to_nid(&lo_fun, &new_vars);
+      if n.is_inv() { (!hi, !lo) } else { (hi, lo) }}
     else { let hilo = self.get_hilo(n); (hilo.hi, hilo.lo) }}}
 
 #[derive(Debug)]


### PR DESCRIPTION
## Summary

This PR introduces **table NIDs with named variables**, allowing functions of up to 5 input variables to be stored directly in the NID as a truth table without allocating BDD nodes. Variable sets are encoded using a combinatorial number system (combinadic) that fits in 27 bits, supporting up to 110 distinct variables.

## Key Changes

### New Modules
- **`src/comb.rs`**: Combinadic encoding/decoding for variable subsets
  - Encodes k-element subsets of {0..109} as a single 27-bit integer
  - Partitions the 27-bit space by arity (2-5) using Pascal's triangle offsets
  - Provides `encode()`, `decode()`, `arity_of()`, and `top_var_of()` functions
  - Precomputed Pascal's triangle for efficient binomial coefficient lookup

- **`src/tbl.rs`**: Truth table operations and alignment
  - Stack-allocated `SmallTbl` struct for truth tables with variable sets
  - Truth table alignment (`expand_table`, `align2`, `align3`) to common variable sets
  - Bitwise operations on tables: `table_and()`, `table_or()`, `table_xor()`, `table_ite()`
  - Degenerate variable detection and removal (`strip_unused_vars`)
  - `make_table_nid()` for constructing normalized NIDs from truth tables
  - MSB-first bit ordering matching the existing `select_bits` convention

### Modified Core Components
- **`src/nid.rs`**:
  - New `NID::fun_with_vars(&[u32], tbl)` constructor for explicit variable sets
  - Updated `NID::vid()` to extract top variable from combinadic for table NIDs
  - Enhanced `Display` impl to show named variables (e.g., `T{x3,x7:1110}`)
  - Added parsing support for named-variable format in `FromStr`

- **`src/nid-fun.rs`**:
  - New methods: `vars()`, `top_vid()`, `contains_var()`, `var_position()`
  - `combinadic()` accessor for the 27-bit variable set encoding
  - Updated `arity()` to decode from combinadic instead of direct field

- **`src/bdd.rs`**:
  - `ite()` now attempts table-based computation before falling back to BDD swarm
  - `when_hi()` optimized for table NIDs to avoid BDD allocation for small subexpressions

- **`src/vhl.rs`**:
  - `tup()` method updated to handle table NIDs via `when()` decomposition

- **`src/lib.rs`**: Exports new `comb` and `tbl` modules

## Implementation Details

- **Bit ordering**: MSB-first, matching existing `select_bits` convention. Entry i is stored at bit (N-1-i) in the u32.
- **Variable signals** (arity 5): x0=0x55555555, x1=0x33333333, x2=0x0F0F0F0F, x3=0x00FF00FF, x4=0x0000FFFF
- **INV normalization**: Functions with f(0,0,...,0)=1 are stored inverted with the INV bit set
- **Degenerate elimination**: Unused variables are automatically removed during `make_table_nid()`
- **Early bailout**: Operations check arity sum before attempting alignment to avoid unnecessary work
- **Comprehensive tests**: 40+ tests covering encode/decode roundtrips, bitwise operations, variable alignment, and edge cases

https://claude.ai/code/session_01177cYvqF68d4XC4rWkT8qh