### PR TITLE
Add sequential fallback for regroup() to handle incomplete parallel swarm

### DIFF
--- a/src/swap.rs
+++ b/src/swap.rs
@@ -672,17 +672,56 @@ impl VhlScaffold {
         QID::DONE => { SwarmCmd::Pass }}});
 
         debug_assert!(self.locked.is_empty());
-        // println!("variables now: {:?}", self.vids);
+
+        // Drain any deferred refcount changes that may have been left behind
+        // by the parallel run (e.g. a refcount delta that got re-deferred onto
+        // a row the swarm later couldn't finish moving). In the happy path
+        // this is a no-op because apply_drcd is already called as each vid
+        // unlocks. Since self.locked is empty now, any stragglers can be
+        // applied directly.
+        let dangling_drcd: Vec<VID> = self.drcd.keys().cloned().collect();
+        for v in dangling_drcd { self.apply_drcd(&v); }
+
+        // If the parallel swarm couldn't finish the reordering — e.g. because
+        // `should_swap` blocked every pairing the planner could assign — fall
+        // back to a sequential bubble-sort via swap(). This is slower but
+        // guaranteed to terminate, and keeps `arrange_vids` from wedging the
+        // next substitution with a bogus `sg` partition. See issues #12, #22.
         let plan2 = self.plan_regroup(&groups);
-        // println!("remaining regroup plan: {:?}", plan2);
         if !plan2.is_empty() {
-          println!("------------------------------------------------");
-          println!("WARNING! reordering operation did not complete!");
-          println!("Regroup failed to make these moves: {:?}", plan2);
-          println!("------------------------------------------------");
-          println!("This is a known bug. See here for status and workarounds:");
-          println!("https://github.com/tangentstorm/bex/issues/12"); }
+          println!("note: parallel regroup left {} moves unfinished; \
+                    completing sequentially (see issue #22). remaining: {:?}",
+                   plan2.len(), plan2);
+          self.regroup_finish_sequential(&groups);
+          debug_assert!(self.plan_regroup(&groups).is_empty(),
+            "sequential regroup fallback did not complete"); }
         self.validate("after regroup()"); }
+
+  /// Sequential fallback used when the parallel regroup swarm can't finish.
+  /// Picks a concrete target ordering consistent with `groups` (preserving
+  /// the current relative order of vars within each group), then bubble-sorts
+  /// via `swap()` until `self.vids` matches that target.
+  fn regroup_finish_sequential(&mut self, groups: &[HashSet<VID>]) {
+    // Build target ordering bottom-to-top: for each group, append the vids
+    // from self.vids that belong to it (preserving their current order).
+    let mut target: Vec<VID> = Vec::with_capacity(self.vids.len());
+    for g in groups {
+      for v in self.vids.iter() {
+        if g.contains(v) { target.push(*v); }}}
+    assert_eq!(target.len(), self.vids.len(),
+      "groups don't fully partition vids in sequential regroup fallback");
+
+    // Selection-sort: for each position i from bottom to top, ensure the var
+    // at position i is target[i]. swap(v) lifts v one row up, so to move
+    // `goal` *down* we repeatedly lift the var immediately below it.
+    for i in 0..target.len() {
+      let goal = target[i];
+      loop {
+        let goal_pos = self.vix(goal)
+          .expect("target vid vanished during sequential regroup");
+        if goal_pos <= i { break; }
+        let below = self.vids[goal_pos - 1];
+        self.swap(below); }}}
 
 
   // like add_ref_ix but defers if row is locked.

--- a/src/test-swap.rs
+++ b/src/test-swap.rs
@@ -282,6 +282,63 @@ fn check_sub(vids:&str, dst_s:&str, v:char, src_s:&str, goal:&str) {
     "Bug #12: regroup() failed on interleaved pattern");
 }
 
+/// Regression test for bug #22: the sequential fallback used by `regroup()`
+/// must be able to complete an arbitrary permutation on its own. `arrange_vids`
+/// relies on `regroup()` leaving the scaffold fully ordered; if the parallel
+/// swarm can't finish (warning-and-return path), the sequential path has to
+/// take over and finish the job. This exercises `regroup_finish_sequential`
+/// directly on a full-reverse permutation.
+#[test] fn test_regroup_finish_sequential_reverse() {
+  let mut xs = VhlScaffold::new();
+  let vars: Vec<VID> = (0..5).map(|i| VID::var(i)).collect();
+  for &v in &vars {
+    xs.push(v);
+    xs.add(v, nid::I, nid::O, true);
+  }
+  // Target: each var in its own singleton group, reversed.
+  // Current: [v0..v4] → target: [v4, v3, v2, v1, v0]
+  let groups: Vec<HashSet<VID>> = vars.iter().rev().map(|&v| s![v]).collect();
+  xs.regroup_finish_sequential(&groups);
+  let expected_order: Vec<VID> = vars.iter().rev().cloned().collect();
+  assert_eq!(xs.vids, expected_order,
+    "sequential regroup fallback did not produce the expected order");
+  // A fresh plan against the same groups should now be empty.
+  let plan_after = xs.plan_regroup(&groups);
+  assert!(plan_after.is_empty(),
+    "Bug #22: sequential fallback left {} moves unfinished: {:?}",
+    plan_after.len(), plan_after);
+}
+
+/// Regression test for bug #22: the sequential fallback must also work when
+/// the target groups contain more than one vid each (the usual `arrange_vids`
+/// pattern of `[d, {rv}, n]`).
+#[test] fn test_regroup_finish_sequential_groups() {
+  let mut xs = VhlScaffold::new();
+  let vars: Vec<VID> = (0..6).map(|i| VID::var(i)).collect();
+  for &v in &vars {
+    xs.push(v);
+    xs.add(v, nid::I, nid::O, true);
+  }
+  // Current: [v0, v1, v2, v3, v4, v5]
+  // Groups bottom-to-top: d={v1,v4}, rv={v2}, n={v0,v3,v5}
+  // Preserving current relative order inside each group:
+  //   d → [v1, v4], rv → [v2], n → [v0, v3, v5]
+  // Expected: [v1, v4, v2, v0, v3, v5]
+  let groups = vec![
+    s![vars[1], vars[4]],
+    s![vars[2]],
+    s![vars[0], vars[3], vars[5]],
+  ];
+  xs.regroup_finish_sequential(&groups);
+  let expected_order = vec![vars[1], vars[4], vars[2], vars[0], vars[3], vars[5]];
+  assert_eq!(xs.vids, expected_order,
+    "sequential regroup fallback did not produce the expected grouped order");
+  let plan_after = xs.plan_regroup(&groups);
+  assert!(plan_after.is_empty(),
+    "Bug #22: sequential fallback left {} moves unfinished: {:?}",
+    plan_after.len(), plan_after);
+}
+
 /// Unit tests for the should_swap function
 /// Tests all the edge cases of the swap decision logic
 #[test] fn test_should_swap_both_moving_up() {


### PR DESCRIPTION
## Summary
This PR adds a sequential bubble-sort fallback to the `regroup()` operation when the parallel swarm cannot complete the variable reordering. This ensures that `arrange_vids` always leaves the scaffold in a fully ordered state, preventing wedging of subsequent substitutions.

## Key Changes

- **Sequential fallback implementation**: Added `regroup_finish_sequential()` method that performs a selection-sort via `swap()` to complete any reordering that the parallel swarm couldn't finish. The method builds a target ordering that preserves the relative order of variables within each group.

- **Improved error handling**: Replaced the warning message about incomplete reordering with a note that the sequential fallback is being invoked. The operation now guarantees completion rather than leaving the scaffold in an inconsistent state.

- **Deferred refcount cleanup**: Added logic to drain any deferred refcount changes (`drcd`) that may have been left behind by the parallel run before attempting the sequential fallback. This ensures the scaffold is in a clean state before the fallback begins.

- **Comprehensive regression tests**: Added two test cases:
  - `test_regroup_finish_sequential_reverse()`: Tests the sequential fallback on a full-reverse permutation (worst case)
  - `test_regroup_finish_sequential_groups()`: Tests the sequential fallback with multi-element groups, matching the typical `arrange_vids` pattern

## Implementation Details

The sequential fallback works by:
1. Building a target ordering that respects the group structure while preserving current relative order within groups
2. Using selection-sort to move each variable to its target position
3. Leveraging the existing `swap()` operation to lift variables upward as needed

This approach is slower than the parallel swarm but is guaranteed to terminate and complete the reordering, addressing issues #12 and #22.

https://claude.ai/code/session_01Rpv8BosSVUAfxGCu8dCvQB