### PR TITLE
profile: optional coz causal-profiler integration (bex#9)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ path = "examples/solve/bench-small.rs"
 default = ["sql"]
 sql = []
 slowtests = []
+# Enable causal profiling via the `coz` crate. See src/coz_profile.rs
+# and doc/coz-profiling.md for usage. Linux-only; 2-5x slowdown while
+# profiling. Off by default.
+coz = ["dep:coz"]
 
 [workspace]
 members = ["py", "api", "ffi"]
@@ -66,6 +70,7 @@ concurrent-queue = "2.1.0"
 crossbeam-channel = "0.5"
 json = "0.12.4"
 rusqlite = { version = "0.31", features = ["bundled"] }
+coz = { version = "0.1", optional = true }
 
 [dev-dependencies]
 bencher = "0.1.5"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ search space of a problem. See [doc/time-to-cover.md](doc/time-to-cover.md)
 for the definition, formula, and how it applies to both branching and
 top-down (BDD/swap) solvers.
 
+## Profiling
+
+Bex has optional [coz][coz] causal-profiler integration behind the `coz`
+cargo feature. See [doc/coz-profiling.md](doc/coz-profiling.md) for
+instructions.
+
+[coz]: https://github.com/plasma-umass/coz
+
 ## Changes in main branch (upcoming version)
 
 - **Table NIDs with named variables:** truth tables of up to 5 inputs are now stored directly in the NID, with the variable set encoded via a combinadic index. `BddBase::ite()` automatically uses truth table operations for small subexpressions before entering the BDD swarm. New modules: `comb` (combinadic encoding), `tbl` (table alignment and operations). New display format: `T{x3,x7:1110}`.

--- a/doc/coz-profiling.md
+++ b/doc/coz-profiling.md
@@ -1,0 +1,68 @@
+# Causal profiling with coz
+
+Bex is instrumented for use with the [coz][coz] causal profiler. Coz is
+*not* a sampling profiler — instead of telling you where a program spends
+time, it tells you which lines would actually speed up the program if
+optimized. For parallel code (which bex has a lot of: `BddSwarm`,
+`VhlSwarm`, `AnfSwarm`, the parallel regroup solver) those are frequently
+different answers.
+
+See issue [#9][issue9] for background on why we want this.
+
+## Build
+
+```sh
+cargo build --release --features coz --example bdd-solve
+```
+
+The `coz` feature is off by default; with it disabled all of the progress
+points defined in `src/coz_profile.rs` expand to no-ops, so normal builds
+pay nothing.
+
+## Profile
+
+Profile a workload by prefixing it with `coz run`:
+
+```sh
+coz run --- target/release/examples/bdd-solve
+```
+
+This produces a `profile.coz` file in the working directory. View it in
+the [coz web viewer][viewer].
+
+## Constraints
+
+- **Linux only** — coz uses `perf_event_open`.
+- Needs **debug symbols** in release builds. The existing
+  `debug = "line-tables-only"` in `Cargo.toml` is already enough.
+- Expect a **2-5× slowdown** while profiling, so this is a "when you
+  have a perf question" tool, not continuous.
+- Only meaningful on **realistic workloads**. Toy inputs won't expose
+  contention patterns.
+
+## Progress points
+
+These are the named progress points currently emitted:
+
+| Name        | Where                                           | Meaning                                                    |
+| ----------- | ----------------------------------------------- | ---------------------------------------------------------- |
+| `bdd-ite`   | `src/bdd/bdd_swarm.rs` `BddJobHandler::work_job`| One ITE job processed by a BDD swarm worker.               |
+| `anf-job`   | `src/anf_swarm.rs` `AnfWorker::work_job`        | One ANF job (xor / and / sub) processed by a swarm worker. |
+| `row-swap`  | `src/swap.rs` `swap()` and `swarm_put_rd()`     | One row-swap committed (serial or parallel regroup).       |
+
+## Adding more progress points
+
+Use one of the macros in `src/coz_profile.rs`:
+
+```rust
+crate::coz_progress!("some-name");       // named progress point
+crate::coz_begin!("span");               // throughput span start
+crate::coz_end!("span");                 // throughput span end
+crate::coz_scope!("span");               // RAII scope guard
+```
+
+When the `coz` feature is disabled, all four expand to `()`.
+
+[coz]: https://github.com/plasma-umass/coz
+[issue9]: https://github.com/tangentstorm/bex/issues/9
+[viewer]: https://plasma-umass.org/coz/

--- a/src/anf_swarm.rs
+++ b/src/anf_swarm.rs
@@ -362,6 +362,9 @@ impl AnfWorker {
   }
 
   fn work_job(&mut self, job:AnfJob) {
+    // Causal-profiler progress point: one unit of ANF work dispatched
+    // to a swarm worker. See `src/coz_profile.rs`.
+    crate::coz_progress!("anf-job");
     let state = self.state.as_ref().unwrap();
     let res = match job {
       AnfJob::Xor(x, y) => {

--- a/src/bdd/bdd_swarm.rs
+++ b/src/bdd/bdd_swarm.rs
@@ -14,6 +14,9 @@ impl VhlJobHandler<NormIteKey> for BddJobHandler {
   type W = VhlWorker<NormIteKey, Self>;
 
   fn work_job(&mut self, w: &mut Self::W, q:NormIteKey) {
+    // Causal-profiler progress point: one unit of ITE work dispatched
+    // to a BDD swarm worker. See `src/coz_profile.rs`.
+    crate::coz_progress!("bdd-ite");
     let res = match self.ite_norm(w, q) {
       ResStep::Nid(n) => w.resolve_job(&q, n),
       ResStep::Wip { v, hi, lo, invert } => {

--- a/src/coz_profile.rs
+++ b/src/coz_profile.rs
@@ -1,0 +1,96 @@
+//! Causal-profiler integration via the [`coz`](https://github.com/plasma-umass/coz) crate.
+//!
+//! `coz` is a *causal* profiler: you annotate meaningful milestones with
+//! *progress points*, and coz simulates virtual speedups of individual
+//! lines of code to estimate how much each one actually contributes to
+//! end-to-end throughput. This is especially useful for parallel code
+//! where the hottest function on a flamegraph is often not the critical
+//! path. See the comments on issue #9 for motivation.
+//!
+//! The macros defined here (`coz_progress!`, `coz_begin!`, `coz_end!`,
+//! `coz_scope!`) expand to calls into the `coz` crate when the `coz`
+//! cargo feature is enabled, and to no-ops otherwise, so they are safe
+//! to leave sprinkled throughout the codebase.
+//!
+//! # Usage
+//!
+//! ```ignore
+//! use bex::coz_progress;
+//! // mark the completion of one unit of work:
+//! coz_progress!("bdd-ite");
+//! ```
+//!
+//! To profile a binary:
+//!
+//! ```text
+//! cargo build --release --features coz --example bdd-solve
+//! coz run --- target/release/examples/bdd-solve
+//! # then open profile.coz in the coz web viewer.
+//! ```
+//!
+//! # Constraints
+//!
+//! - Linux only (uses `perf_event_open`).
+//! - Needs release builds with debug symbols; the existing
+//!   `debug = "line-tables-only"` in `Cargo.toml` is sufficient.
+//! - Expect 2-5x slowdown while profiling.
+
+/// Emit a named coz progress point. Expands to a no-op unless the `coz`
+/// cargo feature is enabled.
+#[cfg(feature = "coz")]
+#[macro_export]
+macro_rules! coz_progress {
+  ($name:literal) => { ::coz::progress!($name) };
+  () => { ::coz::progress!() };
+}
+
+#[cfg(not(feature = "coz"))]
+#[macro_export]
+macro_rules! coz_progress {
+  ($name:literal) => { () };
+  () => { () };
+}
+
+/// Begin a coz throughput scope. Pair with `coz_end!`. No-op without
+/// the `coz` feature.
+#[cfg(feature = "coz")]
+#[macro_export]
+macro_rules! coz_begin {
+  ($name:literal) => { ::coz::begin!($name) };
+}
+
+#[cfg(not(feature = "coz"))]
+#[macro_export]
+macro_rules! coz_begin {
+  ($name:literal) => { () };
+}
+
+/// End a coz throughput scope opened with `coz_begin!`. No-op without
+/// the `coz` feature.
+#[cfg(feature = "coz")]
+#[macro_export]
+macro_rules! coz_end {
+  ($name:literal) => { ::coz::end!($name) };
+}
+
+#[cfg(not(feature = "coz"))]
+#[macro_export]
+macro_rules! coz_end {
+  ($name:literal) => { () };
+}
+
+/// Create a coz throughput scope guard bound to the current lexical
+/// scope. When the guard drops, the scope ends. `coz::scope!` itself
+/// introduces a `_coz_scope_guard` binding; this wrapper just forwards
+/// to it (and is a no-op without the `coz` feature).
+#[cfg(feature = "coz")]
+#[macro_export]
+macro_rules! coz_scope {
+  ($name:literal) => { ::coz::scope!($name); };
+}
+
+#[cfg(not(feature = "coz"))]
+#[macro_export]
+macro_rules! coz_scope {
+  ($name:literal) => { () };
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,3 +34,4 @@ pub mod swap;
 pub mod swarm;
 pub mod vhl_swarm;
 pub mod naf;
+pub mod coz_profile;

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -471,7 +471,9 @@ impl VhlScaffold {
     println!("%stats: dnews:{} unews:{} dels:{}", dnews, unews, dels);
     println!("%vids: {:?}", self.vids);
     println!("%counts: {:?}", counts);
-    #[cfg(test)] { self.validate(format!("after swapping vu:{:?} and vd:{:?}.",vu,vd).as_str()); }}
+    #[cfg(test)] { self.validate(format!("after swapping vu:{:?} and vd:{:?}.",vu,vd).as_str()); }
+    // Causal-profiler progress point: one row-swap completed.
+    crate::coz_progress!("row-swap"); }
 
   /// Reclaim the records for a list of garbage collected nodes.
   /// note: this should ONLY be called from swap() or regroup() because
@@ -847,6 +849,9 @@ impl VhlScaffold {
     let old_uix = self.vix(vu).unwrap();
     let new_uix = old_uix + 1;
     self.vids.swap(old_uix, new_uix);
+
+    // Causal-profiler progress point: one parallel row-swap committed.
+    crate::coz_progress!("row-swap");
 
     //println!("\x1b[36mswapped vu:{} -> vd:{} => {:?}\x1b[0m", vu, vd, self.vids);
     //self.validate(format!("after swapping vd:{:?} with vu:{:?}", vd, vu).as_str());


### PR DESCRIPTION
Closes tangentstorm/bex#9.

## Summary

Adds an optional `coz` cargo feature (off by default) that wires the [coz](https://github.com/plasma-umass/coz) causal profiler into the three parallel solvers. Progress points fire once per unit of worker-thread work:

| Name        | Site                                                | Meaning                                     |
| ----------- | --------------------------------------------------- | ------------------------------------------- |
| `bdd-ite`   | `BddJobHandler::work_job` (`src/bdd/bdd_swarm.rs`)  | one ITE job in BddSwarm                     |
| `anf-job`   | `AnfWorker::work_job` (`src/anf_swarm.rs`)          | one ANF xor/and/sub job                     |
| `row-swap`  | `swap()` and `swarm_put_rd()` (`src/swap.rs`)       | one row-swap committed (serial or parallel) |

Macros (`coz_progress!`, `coz_begin!`, `coz_end!`, `coz_scope!`) live in `src/coz_profile.rs` and compile to `()` when the feature is disabled, so the default build is entirely unaffected.

Usage:

```sh
cargo build --release --features coz --example bdd-solve
coz run --- target/release/examples/bdd-solve
# open profile.coz in the coz viewer
```

Full instructions in `doc/coz-profiling.md`. README links to it.

## Not yet in this PR

I did *not* run coz against any workload — the sandbox I worked in is gVisor, which doesn't implement `perf_event_open`. The instrumentation is ready; the first real run has to happen on a Linux host with perf enabled. See [the follow-up comment on bex#9](https://github.com/tangentstorm/bex/issues/9#issuecomment-4256567507) for the questions the current progress points are aimed at and ideas for follow-on points (`bdd-ite-top`, `vid-lift`, `bdd-run` scope) that only make sense once we see what the first run reveals.

## Test plan

- [x] `cargo build` (without feature) — succeeds
- [x] `cargo build --features coz` — succeeds
- [x] `cargo build --release --features coz --example bdd-solve` — succeeds
- [x] `cargo test --lib` — 161/161 pass
- [x] `cargo test --lib --features coz` — 161/161 pass
- [x] `cargo doc --features coz --no-deps` — no warnings on new code
- [x] `strings` on the release rlib: progress-point names present with `--features coz`, absent without
- [ ] Actual `coz run` on a workload (requires a real Linux host — out of scope for this sandbox)