### PR TITLE
snapshot persistence for scaffolds/BDDs/ANFs + bex-solve driver (bex#6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,39 @@ Older upcoming changes for 0.4.0 live in the README section titled \"Changes in 
   - Added `bench-small` example for quick single-run benchmarking
   - Added [doc/optimization-ideas.md](doc/optimization-ideas.md) with 24 profiling-driven ideas (3 applied, 12 tested/rejected with rationale)
 
+### Persistence
+- **Snapshot persistence for `VhlScaffold`, `BddBase`, and `ANFBase`** (bex#6).
+  Resolves the long-standing request to load and save intermediate
+  solver state. A new `sql_snap` module adds four SQLite tables
+  (`snapshot`, `snapshot_vid`, `snapshot_node`, `snapshot_root`)
+  alongside the existing AST schema; each snapshot captures the
+  graph plus its variable permutation (critical for `SwapSolver`,
+  whose scaffold reordering changes at every `subst` step).
+  Snapshots chain via `parent_id` to form a replay trace.
+  - New public API: `sql_snap::{write_scaffold, write_bdd, write_anf,
+    read_scaffold, read_bdd_into, read_anf_into, list_snapshots}`
+    plus path-based wrappers and `ensure_snap_schema`.
+  - `VhlScaffold`: new `iter_nodes`, `from_raw`, `is_mid_regroup`.
+  - `SwapSolver`: new `dx`, `rv`, `from_parts` for resume.
+  - `ANFBase`: new `nodes`, `tags`, `tags_mut`, `insert_vhl`.
+  - `sql`: new `ensure_schema_pub`, `ensure_schema_tx` helpers so
+    callers can share a transaction with snapshot writes.
+  - Schema is additive — existing AST-only `.sdb` files load
+    unchanged; `list_snapshots` returns empty for files without
+    snapshot tables.
+
 ### Tooling
+- **New binary `bex-sdb`** — CLI for inspecting snapshot databases.
+  Subcommands: `list`, `info`, `dump`, `ast`, `replay`.
+- **New binary `bex-mkproblem`** — generates AST `.sdb` files for
+  primorial factoring problems (`bex-mkproblem -p 4 -o primorial-4.sdb`).
+- **New binary `bex-solve`** — drives `SwapSolver` / `BddBase` /
+  `ANFBase` through the substitution solve loop, auto-committing a
+  snapshot to the same `.sdb` file after every N steps. Supports
+  `--solver swap|bdd|anf`, `--save-every N`, `--resume <snap-id>`,
+  `--timeout <secs>`, and `-o <output.sdb>`.
+- `solve::refine_one` is now `pub` so external drivers can call it.
+
 - Migrated `benches/bench-solve.rs` from [`bencher`](https://crates.io/crates/bencher)
   to [`divan`](https://crates.io/crates/divan) (bex#4). Benchmark output now
   includes median / mean / stddev on a tree-structured terminal report, plus

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,11 @@ path = "examples/shell/bex-shell.rs"
 name = "swarm-shell"
 path = "examples/shell/swarm-shell.rs"
 
+[[bin]]
+name = "bex-sdb"
+path = "src/bin/bex-sdb.rs"
+required-features = ["sql"]
+
 [[example]]
 name = "bdd-solve"
 path = "examples/solve/bdd-solve.rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,16 @@ name = "bex-sdb"
 path = "src/bin/bex-sdb.rs"
 required-features = ["sql"]
 
+[[bin]]
+name = "bex-mkproblem"
+path = "src/bin/bex-mkproblem.rs"
+required-features = ["sql"]
+
+[[bin]]
+name = "bex-solve"
+path = "src/bin/bex-solve.rs"
+required-features = ["sql"]
+
 [[example]]
 name = "bdd-solve"
 path = "examples/solve/bdd-solve.rs"

--- a/src/anf.rs
+++ b/src/anf.rs
@@ -151,6 +151,25 @@ impl Base for ANFBase {
 
 impl ANFBase {
 
+  /// Read-only view of the packed node array. `nodes()[k]` is the `Vhl`
+  /// for the node at index `k`, interpreted as `(v AND hi) XOR lo`.
+  pub fn nodes(&self) -> &[Vhl] { &self.nodes }
+
+  /// Read-only view of the tag table.
+  pub fn tags(&self) -> &HashMap<String, NID> { &self.tags }
+
+  /// Mutable access to the tag table. (Primarily for snapshot loaders
+  /// that need to re-register root names after rebuilding nodes.)
+  pub fn tags_mut(&mut self) -> &mut HashMap<String, NID> { &mut self.tags }
+
+  /// Insert an already-normalized `(v AND hi) XOR lo` node, returning
+  /// its NID. Same semantics as the private `vhl()` helper used by
+  /// `and`/`xor`; exposed for external loaders that need to rebuild an
+  /// ANF graph bottom-up from previously-emitted node data.
+  pub fn insert_vhl(&mut self, v:VID, hi:NID, lo:NID)->NID {
+    self.vhl(v, hi, lo)
+  }
+
   fn fetch(&self, n:NID)->Vhl {
     if n.is_vid() { // variables are (v*I)+O if normal, (v*I)+I if inverted.
       Vhl{v:n.vid(), hi:I, lo: if n.is_inv() { I } else { O } }}

--- a/src/bin/bex-mkproblem.rs
+++ b/src/bin/bex-mkproblem.rs
@@ -1,0 +1,71 @@
+//! Generate an AST `.sdb` file for a primorial factoring problem.
+//!
+//! Usage: bex-mkproblem -p <N> -o <file.sdb>
+//!
+//! Produces an AST representing "find x,y where x<y and x*y == primorial(N)"
+//! using 8-bit factors (16-bit product). The top node is tagged "top".
+
+use std::env;
+use std::process;
+
+
+use bex::int::{GBASE, BInt, X8, X16};
+use bex::ast::ASTBase;
+use bex::sql;
+
+const PRIMES: &[usize] = &[2, 3, 5, 7, 11, 13, 17, 19, 23];
+
+fn primorial(n: usize) -> usize {
+  PRIMES.iter().take(n).product()
+}
+
+fn main() {
+  let args: Vec<String> = env::args().collect();
+  let mut which: usize = 4;
+  let mut outpath: Option<String> = None;
+  let mut i = 1;
+  while i < args.len() {
+    match args[i].as_str() {
+      "-p" => { i += 1; which = args[i].parse().expect("bad -p value"); }
+      "-o" => { i += 1; outpath = Some(args[i].clone()); }
+      "-h" | "--help" => { usage(); process::exit(0); }
+      _ => { eprintln!("unknown arg: {}", args[i]); usage(); process::exit(1); }
+    }
+    i += 1;
+  }
+  let outpath = outpath.unwrap_or_else(|| format!("primorial-{}.sdb", which));
+  if which < 2 || which > PRIMES.len() {
+    eprintln!("primorial must be between 2 and {}", PRIMES.len());
+    process::exit(1);
+  }
+  let k = primorial(which);
+  println!("primorial({}) = {}", which, k);
+  println!("generating AST for: find x,y (8-bit) where x<y and x*y == {}", k);
+
+  // Build the AST using the thread-local GBASE
+  GBASE.with(|gb| gb.replace(ASTBase::empty()));
+  let (y, x) = (X8::def("y", 0), X8::def("x", X8::n()));
+  let lt = x.lt(&y);
+  let xy: X16 = x.times(&y);
+  let kv = X16::new(k);
+  let eq = BInt::eq(&xy, &kv);
+  let top = lt & eq;
+
+  // Swap out the global base and get the raw AST
+  let mut gb = GBASE.with(|gb| gb.replace(ASTBase::empty()));
+  gb.raw_ast_mut().tags.insert("top".to_string(), top.n);
+  let src = gb.raw_ast();
+
+  // Export to .sdb
+  let keep = vec![top.n];
+  sql::export_raw_ast_to_path(src, &outpath, &keep)
+    .unwrap_or_else(|e| { eprintln!("failed to write {}: {}", outpath, e); process::exit(1); });
+
+  println!("wrote {} ({} AST nodes)", outpath, src.len());
+}
+
+fn usage() {
+  eprintln!("Usage: bex-mkproblem -p <N> -o <file.sdb>");
+  eprintln!("  -p N   which primorial (2..9, default 4)");
+  eprintln!("  -o F   output file (default: primorial-N.sdb)");
+}

--- a/src/bin/bex-sdb.rs
+++ b/src/bin/bex-sdb.rs
@@ -71,8 +71,8 @@ fn cmd_list(path: &str) {
     println!("(no snapshots)");
     return;
   }
-  println!("{:>4}  {:>6}  {:>8}  {:>4}  {:>6}  {:>6}  {:>5}  {}",
-           "id", "parent", "kind", "step", "rv", "#nodes", "#vids", "note");
+  println!("{:>4}  {:>6}  {:>8}  {:>4}  {:>6}  {:>6}  {:>5}  note",
+           "id", "parent", "kind", "step", "rv", "#nodes", "#vids");
   for s in &snaps {
     let parent = s.parent.map_or("-".to_string(), |p| format!("{}", p.0));
     let rv = s.rv.map_or("-".to_string(), |v| format!("{}", v));

--- a/src/bin/bex-sdb.rs
+++ b/src/bin/bex-sdb.rs
@@ -1,0 +1,178 @@
+//! CLI tool for inspecting and manipulating bex `.sdb` SQLite databases.
+//!
+//! Usage:
+//!   bex-sdb list    <file.sdb>
+//!   bex-sdb info    <file.sdb> <snap-id>
+//!   bex-sdb dump    <file.sdb> <snap-id>
+//!   bex-sdb ast     <file.sdb>
+//!   bex-sdb replay  <file.sdb> <head-id>
+
+use std::env;
+use std::process;
+use rusqlite::Connection;
+use bex::sql_snap::{self, SnapshotId};
+
+fn main() {
+  let args: Vec<String> = env::args().collect();
+  if args.len() < 3 {
+    usage();
+    process::exit(1);
+  }
+  let cmd = &args[1];
+  let path = &args[2];
+
+  match cmd.as_str() {
+    "list" => cmd_list(path),
+    "info" => {
+      let id = parse_snap_id(&args, 3);
+      cmd_info(path, id);
+    }
+    "dump" => {
+      let id = parse_snap_id(&args, 3);
+      cmd_dump(path, id);
+    }
+    "ast" => cmd_ast(path),
+    "replay" => {
+      let id = parse_snap_id(&args, 3);
+      cmd_replay(path, id);
+    }
+    _ => { eprintln!("unknown command: {}", cmd); usage(); process::exit(1); }
+  }
+}
+
+fn usage() {
+  eprintln!("Usage: bex-sdb <command> <file.sdb> [args...]");
+  eprintln!("Commands:");
+  eprintln!("  list    <file>            List all snapshots");
+  eprintln!("  info    <file> <snap-id>  Show snapshot metadata");
+  eprintln!("  dump    <file> <snap-id>  Dump snapshot nodes");
+  eprintln!("  ast     <file>            Dump AST tags and node count");
+  eprintln!("  replay  <file> <head-id>  Trace snapshot chain from root to head");
+}
+
+fn parse_snap_id(args: &[String], idx: usize) -> SnapshotId {
+  if idx >= args.len() {
+    eprintln!("missing snapshot id argument");
+    usage();
+    process::exit(1);
+  }
+  let n: i64 = args[idx].parse().unwrap_or_else(|_| {
+    eprintln!("bad snapshot id: {}", args[idx]);
+    process::exit(1);
+  });
+  SnapshotId(n)
+}
+
+fn cmd_list(path: &str) {
+  let conn = Connection::open(path).unwrap_or_else(|e| {
+    eprintln!("cannot open {}: {}", path, e); process::exit(1); });
+  let snaps = sql_snap::list_snapshots(&conn).unwrap();
+  if snaps.is_empty() {
+    println!("(no snapshots)");
+    return;
+  }
+  println!("{:>4}  {:>6}  {:>8}  {:>4}  {:>6}  {:>6}  {:>5}  {}",
+           "id", "parent", "kind", "step", "rv", "#nodes", "#vids", "note");
+  for s in &snaps {
+    let parent = s.parent.map_or("-".to_string(), |p| format!("{}", p.0));
+    let rv = s.rv.map_or("-".to_string(), |v| format!("{}", v));
+    let step = s.step.map_or("-".to_string(), |s| format!("{}", s));
+    let note = s.note.as_deref().unwrap_or("-");
+    println!("{:>4}  {:>6}  {:>8}  {:>4}  {:>6}  {:>6}  {:>5}  {}",
+             s.id.0, parent, s.kind.as_str(), step, rv,
+             s.num_nodes, s.vids.len(), note);
+  }
+}
+
+fn cmd_info(path: &str, id: SnapshotId) {
+  let conn = Connection::open(path).unwrap_or_else(|e| {
+    eprintln!("cannot open {}: {}", path, e); process::exit(1); });
+  let snaps = sql_snap::list_snapshots(&conn).unwrap();
+  let snap = snaps.iter().find(|s| s.id == id).unwrap_or_else(|| {
+    eprintln!("snapshot {} not found", id.0); process::exit(1); });
+  println!("Snapshot {}", snap.id.0);
+  println!("  kind:       {}", snap.kind.as_str());
+  println!("  parent:     {}", snap.parent.map_or("-".into(), |p| format!("{}", p.0)));
+  println!("  step:       {}", snap.step.map_or("-".into(), |s| format!("{}", s)));
+  println!("  rv:         {}", snap.rv.map_or("-".into(), |v| format!("{}", v)));
+  println!("  created_at: {}", snap.created_at);
+  println!("  note:       {}", snap.note.as_deref().unwrap_or("-"));
+  println!("  nodes:      {}", snap.num_nodes);
+  println!("  vids ({}):  {:?}", snap.vids.len(), snap.vids);
+
+  // Print roots
+  let mut stmt = conn.prepare(
+    "SELECT name, nid FROM snapshot_root WHERE snapshot_id=?1 ORDER BY name").unwrap();
+  let mut rows = stmt.query(rusqlite::params![id.0]).unwrap();
+  println!("  roots:");
+  while let Some(row) = rows.next().unwrap() {
+    let name: String = row.get(0).unwrap();
+    let nid: String = row.get(1).unwrap();
+    println!("    {} = {}", name, nid);
+  }
+}
+
+fn cmd_dump(path: &str, id: SnapshotId) {
+  let conn = Connection::open(path).unwrap_or_else(|e| {
+    eprintln!("cannot open {}: {}", path, e); process::exit(1); });
+  let mut stmt = conn.prepare(
+    "SELECT ix, vid, hi, lo, irc, erc FROM snapshot_node WHERE snapshot_id=?1 ORDER BY ix"
+  ).unwrap();
+  let mut rows = stmt.query(rusqlite::params![id.0]).unwrap();
+  println!("{:>6}  {:>6}  {:>10}  {:>10}  {:>4}  {:>4}",
+           "ix", "vid", "hi", "lo", "irc", "erc");
+  while let Some(row) = rows.next().unwrap() {
+    let ix: i64 = row.get(0).unwrap();
+    let vid: String = row.get(1).unwrap();
+    let hi: String = row.get(2).unwrap();
+    let lo: String = row.get(3).unwrap();
+    let irc: Option<i64> = row.get(4).unwrap();
+    let erc: Option<i64> = row.get(5).unwrap();
+    println!("{:>6}  {:>6}  {:>10}  {:>10}  {:>4}  {:>4}",
+             ix, vid, hi, lo,
+             irc.map_or("-".into(), |n| format!("{}", n)),
+             erc.map_or("-".into(), |n| format!("{}", n)));
+  }
+}
+
+fn cmd_ast(path: &str) {
+  let conn = Connection::open(path).unwrap_or_else(|e| {
+    eprintln!("cannot open {}: {}", path, e); process::exit(1); });
+  let node_count: i64 = conn.query_row(
+    "SELECT COUNT(*) FROM ast_node", [], |row| row.get(0)
+  ).unwrap_or(0);
+  println!("AST nodes: {}", node_count);
+  let mut stmt = conn.prepare("SELECT name, nid FROM tag ORDER BY name").unwrap();
+  let mut rows = stmt.query([]).unwrap();
+  println!("Tags:");
+  while let Some(row) = rows.next().unwrap() {
+    let name: String = row.get(0).unwrap();
+    let nid: String = row.get(1).unwrap();
+    println!("  {} = {}", name, nid);
+  }
+}
+
+fn cmd_replay(path: &str, head_id: SnapshotId) {
+  let conn = Connection::open(path).unwrap_or_else(|e| {
+    eprintln!("cannot open {}: {}", path, e); process::exit(1); });
+  let snaps = sql_snap::list_snapshots(&conn).unwrap();
+  // Walk backwards from head to root
+  let mut chain: Vec<&sql_snap::SnapshotMeta> = Vec::new();
+  let mut cur = Some(head_id);
+  while let Some(id) = cur {
+    let snap = snaps.iter().find(|s| s.id == id).unwrap_or_else(|| {
+      eprintln!("snapshot {} not found in chain", id.0); process::exit(1); });
+    chain.push(snap);
+    cur = snap.parent;
+  }
+  chain.reverse();
+  println!("{:>4}  {:>4}  {:>6}  {:>8}",
+           "id", "step", "rv", "kind");
+  for s in &chain {
+    let rv = s.rv.map_or("-".to_string(), |v| format!("{}", v));
+    let step = s.step.map_or("-".to_string(), |s| format!("{}", s));
+    println!("{:>4}  {:>4}  {:>6}  {:>8}",
+             s.id.0, step, rv, s.kind.as_str());
+  }
+}
+

--- a/src/bin/bex-solve.rs
+++ b/src/bin/bex-solve.rs
@@ -153,7 +153,7 @@ fn run_swap(cfg: &Config, db_path: &str, src: &RawASTBase, _sorted_top: SrcNid, 
              solver.scaffold().num_nodes());
 
     // Auto-save
-    if cfg.save_every > 0 && steps_done % cfg.save_every == 0 {
+    if cfg.save_every > 0 && steps_done.is_multiple_of(cfg.save_every) {
       let tx = conn.transaction().unwrap();
       let sid = sql_snap::write_scaffold(&tx, SnapshotMetaInput {
         parent: parent_snap,
@@ -228,7 +228,7 @@ fn run_bdd(cfg: &Config, db_path: &str, src: &RawASTBase, _sorted_top: SrcNid, t
     println!("step {:>5}/{:<5}  vir={:<6}  {:>6}ms",
              total_steps - step, total_steps, format!("v{:X}", step), ms);
 
-    if cfg.save_every > 0 && steps_done % cfg.save_every == 0 {
+    if cfg.save_every > 0 && steps_done.is_multiple_of(cfg.save_every) {
       let tx = conn.transaction().unwrap();
       let sid = sql_snap::write_bdd(&tx, SnapshotMetaInput {
         parent: parent_snap, step: Some((total_steps - step) as u32),
@@ -279,7 +279,7 @@ fn run_anf(cfg: &Config, db_path: &str, src: &RawASTBase, _sorted_top: SrcNid, t
     println!("step {:>5}/{:<5}  vir={:<6}  {:>6}ms",
              total_steps - step, total_steps, format!("v{:X}", step), ms);
 
-    if cfg.save_every > 0 && steps_done % cfg.save_every == 0 {
+    if cfg.save_every > 0 && steps_done.is_multiple_of(cfg.save_every) {
       let tx = conn.transaction().unwrap();
       let sid = sql_snap::write_anf(&tx, SnapshotMetaInput {
         parent: parent_snap, step: Some((total_steps - step) as u32),

--- a/src/bin/bex-solve.rs
+++ b/src/bin/bex-solve.rs
@@ -1,0 +1,296 @@
+//! Solve an AST problem file, auto-committing snapshots after each step.
+//!
+//! Usage: bex-solve [options] <file.sdb>
+//!
+//! Options:
+//!   --solver swap|bdd|anf   (default: swap)
+//!   --save-every N          save a snapshot every N steps (default: 1)
+//!   --resume <snap-id>      resume from a saved snapshot
+//!   --timeout <secs>        stop after this many seconds
+//!   -o <output.sdb>         write snapshots to a different file
+
+use std::env;
+use std::process;
+use std::time::Instant;
+
+use rusqlite::Connection;
+use bex::nid::NID;
+use bex::vid::VID;
+use bex::base::Base;
+use bex::solve::{self, SrcNid, DstNid, SubSolver};
+use bex::swap::SwapSolver;
+use bex::bdd::BddBase;
+use bex::anf::ANFBase;
+use bex::sql;
+use bex::sql_snap::{self, SnapshotId, SnapshotMetaInput};
+use bex::ast::RawASTBase;
+use bex::ops::Ops;
+
+#[derive(Debug, Clone)]
+struct Config {
+  input: String,
+  output: Option<String>,
+  solver: String,
+  save_every: usize,
+  resume: Option<i64>,
+  timeout_secs: Option<u64>,
+}
+
+fn parse_args() -> Config {
+  let args: Vec<String> = env::args().collect();
+  let mut cfg = Config {
+    input: String::new(), output: None, solver: "swap".into(),
+    save_every: 1, resume: None, timeout_secs: None,
+  };
+  let mut i = 1;
+  while i < args.len() {
+    match args[i].as_str() {
+      "--solver" => { i += 1; cfg.solver = args[i].clone(); }
+      "--save-every" => { i += 1; cfg.save_every = args[i].parse().expect("bad --save-every"); }
+      "--resume" => { i += 1; cfg.resume = Some(args[i].parse().expect("bad --resume")); }
+      "--timeout" => { i += 1; cfg.timeout_secs = Some(args[i].parse().expect("bad --timeout")); }
+      "-o" => { i += 1; cfg.output = Some(args[i].clone()); }
+      "-h" | "--help" => { usage(); process::exit(0); }
+      s if s.starts_with('-') => { eprintln!("unknown option: {}", s); usage(); process::exit(1); }
+      _ => { cfg.input = args[i].clone(); }
+    }
+    i += 1;
+  }
+  if cfg.input.is_empty() { eprintln!("missing input file"); usage(); process::exit(1); }
+  cfg
+}
+
+fn usage() {
+  eprintln!("Usage: bex-solve [options] <file.sdb>");
+  eprintln!("  --solver swap|bdd|anf   solver backend (default: swap)");
+  eprintln!("  --save-every N          snapshot every N steps (default: 1)");
+  eprintln!("  --resume <snap-id>      resume from a saved snapshot");
+  eprintln!("  --timeout <secs>        wall-clock timeout");
+  eprintln!("  -o <output.sdb>         write snapshots here instead of input file");
+}
+
+fn main() {
+  let cfg = parse_args();
+  let db_path = cfg.output.as_deref().unwrap_or(&cfg.input);
+
+  // Load AST
+  let (src0, _keep) = sql::import_raw_ast_from_path(&cfg.input)
+    .unwrap_or_else(|e| { eprintln!("failed to load {}: {}", cfg.input, e); process::exit(1); });
+  let top_nid = *src0.tags.get("top")
+    .unwrap_or_else(|| { eprintln!("no 'top' tag in AST"); process::exit(1); });
+  println!("loaded AST: {} nodes, top={:?}", src0.len(), top_nid);
+
+  // Sort by cost (deterministic — same result on resume)
+  let (src, sorted_top) = solve::sort_by_cost(&src0, SrcNid { n: top_nid });
+  let total_steps = sorted_top.n.idx();
+  println!("sorted AST: {} nodes, {} steps to solve", src.len(), total_steps + 1);
+
+  match cfg.solver.as_str() {
+    "swap" => run_swap(&cfg, db_path, &src, sorted_top, total_steps),
+    "bdd"  => run_bdd(&cfg, db_path, &src, sorted_top, total_steps),
+    "anf"  => run_anf(&cfg, db_path, &src, sorted_top, total_steps),
+    _ => { eprintln!("unknown solver: {}", cfg.solver); process::exit(1); }
+  }
+}
+
+// -----------------------------------------------------------------------
+// SwapSolver driver
+// -----------------------------------------------------------------------
+
+fn run_swap(cfg: &Config, db_path: &str, src: &RawASTBase, _sorted_top: SrcNid, total_steps: usize) {
+  let mut conn = Connection::open(db_path)
+    .unwrap_or_else(|e| { eprintln!("open {}: {}", db_path, e); process::exit(1); });
+
+  // Ensure schema exists
+  { let tx = conn.transaction().unwrap();
+    sql::ensure_schema_tx(&tx).unwrap();
+    sql_snap::ensure_snap_schema(&tx).unwrap();
+    tx.commit().unwrap(); }
+
+  let (mut solver, mut step, mut ctx, mut parent_snap) = if let Some(snap_id) = cfg.resume {
+    // Resume from snapshot
+    let (sc, roots) = sql_snap::read_scaffold(&conn, SnapshotId(snap_id))
+      .unwrap_or_else(|e| { eprintln!("resume failed: {}", e); process::exit(1); });
+    let snaps = sql_snap::list_snapshots(&conn).unwrap();
+    let snap = snaps.iter().find(|s| s.id.0 == snap_id)
+      .unwrap_or_else(|| { eprintln!("snapshot {} not found", snap_id); process::exit(1); });
+    let saved_step = snap.step.unwrap_or(0) as usize;
+    let dx = roots.iter().find(|(n, _)| n == "ctx").map(|(_, n)| *n)
+      .unwrap_or_else(|| { eprintln!("no 'ctx' root in snapshot"); process::exit(1); });
+    let s = SwapSolver::from_parts(sc, dx);
+    println!("resumed from snapshot {} at step {}", snap_id, saved_step);
+    (s, saved_step, DstNid { n: dx }, Some(SnapshotId(snap_id)))
+  } else {
+    // Fresh start
+    let top_v = VID::vir(total_steps as u32);
+    let mut s = SwapSolver::new();
+    let ctx_nid = s.init(top_v);
+    (s, total_steps, DstNid { n: ctx_nid }, None)
+  };
+
+  let start = Instant::now();
+  let mut steps_done: usize = 0;
+
+  // Main solve loop
+  while !(ctx.n.is_var() || ctx.n.is_const()) {
+    if let Some(timeout) = cfg.timeout_secs {
+      if start.elapsed().as_secs() >= timeout {
+        println!("timeout after {} steps ({:.1}s)", steps_done, start.elapsed().as_secs_f64());
+        break;
+      }
+    }
+    let v = VID::vir(step as u32);
+    let step_start = Instant::now();
+    let _old = ctx;
+    ctx = refine_one_swap(&mut solver, v, src, ctx);
+    let ms = step_start.elapsed().as_millis();
+
+    steps_done += 1;
+    let remaining = step;
+    println!("step {:>5}/{:<5}  vir={:<6}  {:>6}ms  nodes={}",
+             total_steps - remaining, total_steps,
+             format!("v{:X}", step), ms,
+             solver.scaffold().num_nodes());
+
+    // Auto-save
+    if cfg.save_every > 0 && steps_done % cfg.save_every == 0 {
+      let tx = conn.transaction().unwrap();
+      let sid = sql_snap::write_scaffold(&tx, SnapshotMetaInput {
+        parent: parent_snap,
+        step: Some((total_steps - remaining) as u32),
+        rv: Some(v),
+        note: None,
+      }, solver.scaffold(), &[("ctx".into(), ctx.n)]).unwrap();
+      tx.commit().unwrap();
+      parent_snap = Some(sid);
+    }
+
+    if step == 0 { break } else { step -= 1; }
+  }
+
+  // Final save
+  { let tx = conn.transaction().unwrap();
+    let sid = sql_snap::write_scaffold(&tx, SnapshotMetaInput {
+      parent: parent_snap,
+      step: Some(total_steps as u32),
+      rv: None,
+      note: Some("final".into()),
+    }, solver.scaffold(), &[("ctx".into(), ctx.n)]).unwrap();
+    tx.commit().unwrap();
+    println!("saved final snapshot {}", sid.0); }
+
+  let elapsed = start.elapsed();
+  println!("done: {} steps in {:.3}s, result={:?}", steps_done, elapsed.as_secs_f64(), ctx.n);
+}
+
+fn refine_one_swap(solver: &mut SwapSolver, v: VID, src: &RawASTBase, d: DstNid) -> DstNid {
+  let ctx = d.n;
+  let ops = src.get_ops(NID::ixn(v.vir_ix()));
+  let cn = |x0: &NID| -> NID {
+    if x0.is_fun() { *x0 } else { solve::convert_nid(SrcNid { n: *x0 }).n }
+  };
+  let def: Ops = Ops::RPN(ops.to_rpn().map(cn).collect());
+  DstNid { n: solver.subst(ctx, v, &def) }
+}
+
+// -----------------------------------------------------------------------
+// BDD driver
+// -----------------------------------------------------------------------
+
+fn run_bdd(cfg: &Config, db_path: &str, src: &RawASTBase, _sorted_top: SrcNid, total_steps: usize) {
+  let mut conn = Connection::open(db_path)
+    .unwrap_or_else(|e| { eprintln!("open {}: {}", db_path, e); process::exit(1); });
+  { let tx = conn.transaction().unwrap();
+    sql::ensure_schema_tx(&tx).unwrap();
+    sql_snap::ensure_snap_schema(&tx).unwrap();
+    tx.commit().unwrap(); }
+
+  let mut bdd = BddBase::new();
+  let mut step = total_steps;
+  let top_v = VID::vir(step as u32);
+  let mut ctx = DstNid { n: bdd.init(top_v) };
+  let mut parent_snap: Option<SnapshotId> = None;
+  let start = Instant::now();
+  let mut steps_done: usize = 0;
+
+  while !(ctx.n.is_var() || ctx.n.is_const()) {
+    if let Some(timeout) = cfg.timeout_secs {
+      if start.elapsed().as_secs() >= timeout {
+        println!("timeout after {} steps", steps_done);
+        break;
+      }
+    }
+    let v = VID::vir(step as u32);
+    let step_start = Instant::now();
+    ctx = solve::refine_one(&mut bdd, v, src, ctx);
+    let ms = step_start.elapsed().as_millis();
+    steps_done += 1;
+    println!("step {:>5}/{:<5}  vir={:<6}  {:>6}ms",
+             total_steps - step, total_steps, format!("v{:X}", step), ms);
+
+    if cfg.save_every > 0 && steps_done % cfg.save_every == 0 {
+      let tx = conn.transaction().unwrap();
+      let sid = sql_snap::write_bdd(&tx, SnapshotMetaInput {
+        parent: parent_snap, step: Some((total_steps - step) as u32),
+        rv: Some(v), note: None,
+      }, &bdd, &[("ctx".into(), ctx.n)]).unwrap();
+      tx.commit().unwrap();
+      parent_snap = Some(sid);
+    }
+    if step == 0 { break } else { step -= 1; }
+  }
+
+  println!("done: {} steps in {:.3}s, result={:?}",
+           steps_done, start.elapsed().as_secs_f64(), ctx.n);
+}
+
+// -----------------------------------------------------------------------
+// ANF driver
+// -----------------------------------------------------------------------
+
+fn run_anf(cfg: &Config, db_path: &str, src: &RawASTBase, _sorted_top: SrcNid, total_steps: usize) {
+  let mut conn = Connection::open(db_path)
+    .unwrap_or_else(|e| { eprintln!("open {}: {}", db_path, e); process::exit(1); });
+  { let tx = conn.transaction().unwrap();
+    sql::ensure_schema_tx(&tx).unwrap();
+    sql_snap::ensure_snap_schema(&tx).unwrap();
+    tx.commit().unwrap(); }
+
+  let mut anf = ANFBase::new();
+  let mut step = total_steps;
+  let top_v = VID::vir(step as u32);
+  let mut ctx = DstNid { n: anf.init(top_v) };
+  let mut parent_snap: Option<SnapshotId> = None;
+  let start = Instant::now();
+  let mut steps_done: usize = 0;
+
+  while !(ctx.n.is_var() || ctx.n.is_const()) {
+    if let Some(timeout) = cfg.timeout_secs {
+      if start.elapsed().as_secs() >= timeout {
+        println!("timeout after {} steps", steps_done);
+        break;
+      }
+    }
+    let v = VID::vir(step as u32);
+    let step_start = Instant::now();
+    ctx = solve::refine_one(&mut anf, v, src, ctx);
+    let ms = step_start.elapsed().as_millis();
+    steps_done += 1;
+    println!("step {:>5}/{:<5}  vir={:<6}  {:>6}ms",
+             total_steps - step, total_steps, format!("v{:X}", step), ms);
+
+    if cfg.save_every > 0 && steps_done % cfg.save_every == 0 {
+      let tx = conn.transaction().unwrap();
+      let sid = sql_snap::write_anf(&tx, SnapshotMetaInput {
+        parent: parent_snap, step: Some((total_steps - step) as u32),
+        rv: Some(v), note: None,
+      }, &anf, &[("ctx".into(), ctx.n)]).unwrap();
+      tx.commit().unwrap();
+      parent_snap = Some(sid);
+    }
+    if step == 0 { break } else { step -= 1; }
+  }
+
+  println!("done: {} steps in {:.3}s, result={:?}",
+           steps_done, start.elapsed().as_secs_f64(), ctx.n);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ pub mod apl;
 pub mod int;
 #[cfg(feature = "sql")]
 pub mod sql;
+#[cfg(feature = "sql")]
+pub mod sql_snap;
 pub mod anf;
 pub mod anf_swarm;
 pub mod swap;

--- a/src/solve.rs
+++ b/src/solve.rs
@@ -153,7 +153,7 @@ pub fn convert_nid(sn:SrcNid)->DstNid {
   DstNid{ n: r } }
 
 /// replace node in destination with its definition form source
-fn refine_one(dst: &mut dyn SubSolver, v:VID, src:&RawASTBase, d:DstNid)->DstNid {
+pub fn refine_one(dst: &mut dyn SubSolver, v:VID, src:&RawASTBase, d:DstNid)->DstNid {
   // println!("refine_one({:?})", d)
   let ctx = d.n;
   let ops = src.get_ops(NID::ixn(v.vir_ix()));

--- a/src/sql.rs
+++ b/src/sql.rs
@@ -53,6 +53,21 @@ fn ensure_schema(tx: &Transaction<'_>) -> Result<()> {
   Ok(())
 }
 
+/// Public version of `ensure_schema` for use by `sql_snap` path wrappers
+/// that need to guarantee the `meta` table exists before writing
+/// `snap.fmt.version`.
+pub fn ensure_schema_pub(conn: &Connection) -> Result<()> {
+  let tx = conn.unchecked_transaction()?;
+  ensure_schema(&tx)?;
+  tx.commit()
+}
+
+/// Public version of `ensure_schema` that takes a `Transaction` directly,
+/// for callers already inside a transaction.
+pub fn ensure_schema_tx(tx: &Transaction<'_>) -> Result<()> {
+  ensure_schema(tx)
+}
+
 
 fn clear_schema(tx: &Transaction<'_>) -> Result<()> {
   tx.execute("DELETE FROM ast_edge", [])?;

--- a/src/sql_snap.rs
+++ b/src/sql_snap.rs
@@ -21,6 +21,9 @@ use crate::bdd::BddBase;
 use crate::anf::ANFBase;
 use crate::vhl::Walkable;
 
+/// (ix, vid, hi_str, lo_str, irc, erc) — row format used by node writers
+type NodeRow = (usize, VID, String, String, Option<usize>, Option<usize>);
+
 // -----------------------------------------------------------------------
 // Public types
 // -----------------------------------------------------------------------
@@ -152,7 +155,7 @@ fn insert_snapshot_row(
       m.parent.map(|p| p.0),
       kind.as_str(),
       m.step.map(|s| s as i64),
-      m.rv.map(|v| vid_to_string(v)),
+      m.rv.map(vid_to_string),
       now_unix(),
       m.note.as_deref(),
     ],
@@ -171,7 +174,7 @@ fn insert_vids(tx: &Transaction<'_>, sid: SnapshotId, vids: &[VID]) -> Result<()
 
 fn insert_nodes(
   tx: &Transaction<'_>, sid: SnapshotId,
-  nodes: &[(usize, VID, String, String, Option<usize>, Option<usize>)],
+  nodes: &[NodeRow],
 ) -> Result<()> {
   let mut stmt = tx.prepare(
     "INSERT INTO snapshot_node(snapshot_id, ix, vid, hi, lo, irc, erc) VALUES(?1,?2,?3,?4,?5,?6,?7)")?;
@@ -229,7 +232,7 @@ pub fn write_bdd(
   // Walk all roots bottom-up, assigning snapshot-local indices.
   let mut global_to_local: HashMap<NID, usize> = HashMap::new();
   let mut local_ix: usize = 1; // 0 reserved for sentinel
-  let mut node_rows: Vec<(usize, VID, String, String, Option<usize>, Option<usize>)> = Vec::new();
+  let mut node_rows: Vec<NodeRow> = Vec::new();
   let mut vids_seen: Vec<VID> = Vec::new();
   let mut vid_set = std::collections::HashSet::new();
 
@@ -287,7 +290,7 @@ pub fn write_anf(
   // reachable nodes and assign snapshot-local indices.
   let mut global_to_local: HashMap<NID, usize> = HashMap::new();
   let mut local_ix: usize = 1;
-  let mut node_rows: Vec<(usize, VID, String, String, Option<usize>, Option<usize>)> = Vec::new();
+  let mut node_rows: Vec<NodeRow> = Vec::new();
   let mut vids_seen: Vec<VID> = Vec::new();
   let mut vid_set = std::collections::HashSet::new();
 

--- a/src/sql_snap.rs
+++ b/src/sql_snap.rs
@@ -1,0 +1,750 @@
+//! Snapshot persistence for scaffolds, BDDs, and ANFs in SQLite.
+//!
+//! This module adds four tables (`snapshot`, `snapshot_vid`,
+//! `snapshot_node`, `snapshot_root`) alongside the existing AST schema
+//! in `sql.rs`.  Each snapshot captures the full graph at a point in
+//! time and optionally chains to a parent snapshot to form a replay
+//! trace.
+
+use std::path::Path;
+use std::str::FromStr;
+use std::collections::HashMap;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use rusqlite::{params, Connection, Transaction, Result};
+
+use crate::nid::NID;
+use crate::vid::VID;
+use crate::vhl::Vhl;
+use crate::swap::VhlScaffold;
+use crate::bdd::BddBase;
+use crate::anf::ANFBase;
+use crate::vhl::Walkable;
+
+// -----------------------------------------------------------------------
+// Public types
+// -----------------------------------------------------------------------
+
+/// Opaque handle returned by every write and used by every read.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct SnapshotId(pub i64);
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SnapshotKind { Scaffold, Bdd, Anf }
+
+impl SnapshotKind {
+  pub fn as_str(&self) -> &'static str {
+    match self { Self::Scaffold => "scaffold", Self::Bdd => "bdd", Self::Anf => "anf" }
+  }
+  pub fn from_str_kind(s: &str) -> Self {
+    match s { "scaffold" => Self::Scaffold, "bdd" => Self::Bdd, "anf" => Self::Anf,
+              _ => panic!("unknown snapshot kind: {}", s) }
+  }
+}
+
+#[derive(Clone, Debug)]
+pub struct SnapshotMeta {
+  pub id: SnapshotId,
+  pub parent: Option<SnapshotId>,
+  pub kind: SnapshotKind,
+  pub step: Option<u32>,
+  pub rv: Option<VID>,
+  pub note: Option<String>,
+  pub created_at: i64,
+  pub vids: Vec<VID>,
+  pub num_nodes: usize,
+}
+
+/// Input struct for creating a new snapshot (id and created_at are auto-filled).
+pub struct SnapshotMetaInput {
+  pub parent: Option<SnapshotId>,
+  pub step: Option<u32>,
+  pub rv: Option<VID>,
+  pub note: Option<String>,
+}
+
+// -----------------------------------------------------------------------
+// Schema
+// -----------------------------------------------------------------------
+
+const SNAP_SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS snapshot(
+  id         INTEGER PRIMARY KEY,
+  parent_id  INTEGER,
+  kind       TEXT NOT NULL,
+  step       INTEGER,
+  rv         TEXT,
+  created_at INTEGER NOT NULL,
+  note       TEXT,
+  FOREIGN KEY(parent_id) REFERENCES snapshot(id));
+CREATE INDEX IF NOT EXISTS snapshot_parent ON snapshot(parent_id);
+
+CREATE TABLE IF NOT EXISTS snapshot_vid(
+  snapshot_id INTEGER NOT NULL,
+  ord         INTEGER NOT NULL,
+  vid         TEXT NOT NULL,
+  PRIMARY KEY(snapshot_id, ord),
+  FOREIGN KEY(snapshot_id) REFERENCES snapshot(id));
+
+CREATE TABLE IF NOT EXISTS snapshot_node(
+  snapshot_id INTEGER NOT NULL,
+  ix          INTEGER NOT NULL,
+  vid         TEXT NOT NULL,
+  hi          TEXT NOT NULL,
+  lo          TEXT NOT NULL,
+  irc         INTEGER,
+  erc         INTEGER,
+  PRIMARY KEY(snapshot_id, ix),
+  FOREIGN KEY(snapshot_id) REFERENCES snapshot(id));
+CREATE INDEX IF NOT EXISTS snapshot_node_vid ON snapshot_node(snapshot_id, vid);
+
+CREATE TABLE IF NOT EXISTS snapshot_root(
+  snapshot_id INTEGER NOT NULL,
+  name        TEXT NOT NULL,
+  nid         TEXT NOT NULL,
+  PRIMARY KEY(snapshot_id, name),
+  FOREIGN KEY(snapshot_id) REFERENCES snapshot(id));
+"#;
+
+const SNAP_FMT_VERSION: &str = "0.1";
+
+/// Create the snapshot tables if they don't already exist.
+pub fn ensure_snap_schema(tx: &Transaction<'_>) -> Result<()> {
+  tx.execute_batch(SNAP_SCHEMA)?;
+  tx.execute(
+    "INSERT OR REPLACE INTO meta(k, v) VALUES(?1, ?2)",
+    params!["snap.fmt.version", SNAP_FMT_VERSION],
+  )?;
+  Ok(())
+}
+
+// -----------------------------------------------------------------------
+// VID helpers (parse "x3" / "v7" / "T" / "NoV")
+// -----------------------------------------------------------------------
+
+fn vid_to_string(v: VID) -> String { format!("{}", v) }
+
+fn vid_from_string(s: &str) -> VID {
+  match s {
+    "T" => VID::top(),
+    "NoV" => VID::nov(),
+    _ => {
+      let nid = NID::from_str(s).unwrap_or_else(|e| panic!("bad vid string '{}': {}", s, e));
+      nid.vid()
+    }
+  }
+}
+
+fn now_unix() -> i64 {
+  SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_secs() as i64
+}
+
+// -----------------------------------------------------------------------
+// Insert helpers (shared by all three writers)
+// -----------------------------------------------------------------------
+
+fn insert_snapshot_row(
+  tx: &Transaction<'_>, m: &SnapshotMetaInput, kind: &SnapshotKind,
+) -> Result<SnapshotId> {
+  tx.execute(
+    "INSERT INTO snapshot(parent_id, kind, step, rv, created_at, note) VALUES(?1,?2,?3,?4,?5,?6)",
+    params![
+      m.parent.map(|p| p.0),
+      kind.as_str(),
+      m.step.map(|s| s as i64),
+      m.rv.map(|v| vid_to_string(v)),
+      now_unix(),
+      m.note.as_deref(),
+    ],
+  )?;
+  Ok(SnapshotId(tx.last_insert_rowid()))
+}
+
+fn insert_vids(tx: &Transaction<'_>, sid: SnapshotId, vids: &[VID]) -> Result<()> {
+  let mut stmt = tx.prepare(
+    "INSERT INTO snapshot_vid(snapshot_id, ord, vid) VALUES(?1,?2,?3)")?;
+  for (ord, v) in vids.iter().enumerate() {
+    stmt.execute(params![sid.0, ord as i64, vid_to_string(*v)])?;
+  }
+  Ok(())
+}
+
+fn insert_nodes(
+  tx: &Transaction<'_>, sid: SnapshotId,
+  nodes: &[(usize, VID, String, String, Option<usize>, Option<usize>)],
+) -> Result<()> {
+  let mut stmt = tx.prepare(
+    "INSERT INTO snapshot_node(snapshot_id, ix, vid, hi, lo, irc, erc) VALUES(?1,?2,?3,?4,?5,?6,?7)")?;
+  for (ix, v, hi, lo, irc, erc) in nodes {
+    stmt.execute(params![
+      sid.0, *ix as i64, vid_to_string(*v),
+      hi.as_str(), lo.as_str(),
+      irc.map(|x| x as i64), erc.map(|x| x as i64),
+    ])?;
+  }
+  Ok(())
+}
+
+fn insert_roots(
+  tx: &Transaction<'_>, sid: SnapshotId, roots: &[(String, NID)],
+) -> Result<()> {
+  let mut stmt = tx.prepare(
+    "INSERT INTO snapshot_root(snapshot_id, name, nid) VALUES(?1,?2,?3)")?;
+  for (name, nid) in roots {
+    stmt.execute(params![sid.0, name.as_str(), format!("{}", nid)])?;
+  }
+  Ok(())
+}
+
+// -----------------------------------------------------------------------
+// Writers
+// -----------------------------------------------------------------------
+
+/// Write a `VhlScaffold` snapshot. Returns the new snapshot id.
+pub fn write_scaffold(
+  tx: &Transaction<'_>, m: SnapshotMetaInput,
+  sc: &VhlScaffold, roots: &[(String, NID)],
+) -> Result<SnapshotId> {
+  ensure_snap_schema(tx)?;
+  let sid = insert_snapshot_row(tx, &m, &SnapshotKind::Scaffold)?;
+  insert_vids(tx, sid, sc.vids())?;
+  let raw = sc.iter_nodes();
+  let nodes: Vec<_> = raw.iter().map(|(ix, vhl, irc, erc)| {
+    (*ix, vhl.v, format!("{}", vhl.hi), format!("{}", vhl.lo),
+     Some(*irc), Some(*erc))
+  }).collect();
+  insert_nodes(tx, sid, &nodes)?;
+  insert_roots(tx, sid, roots)?;
+  Ok(sid)
+}
+
+/// Write a BDD snapshot by walking from the given roots.
+pub fn write_bdd(
+  tx: &Transaction<'_>, m: SnapshotMetaInput,
+  bdd: &BddBase, roots: &[(String, NID)],
+) -> Result<SnapshotId> {
+  ensure_snap_schema(tx)?;
+  let sid = insert_snapshot_row(tx, &m, &SnapshotKind::Bdd)?;
+
+  // Walk all roots bottom-up, assigning snapshot-local indices.
+  let mut global_to_local: HashMap<NID, usize> = HashMap::new();
+  let mut local_ix: usize = 1; // 0 reserved for sentinel
+  let mut node_rows: Vec<(usize, VID, String, String, Option<usize>, Option<usize>)> = Vec::new();
+  let mut vids_seen: Vec<VID> = Vec::new();
+  let mut vid_set = std::collections::HashSet::new();
+
+  let root_nids: Vec<NID> = roots.iter().map(|(_, n)| *n).collect();
+  bdd.walk_up_each(&root_nids, &mut |nid, vid, hi, lo| {
+    let raw = nid.raw();
+    if global_to_local.contains_key(&raw) { return; }
+    if raw.is_const() || raw.is_vid() { return; } // leaves don't need rows
+    let ix = local_ix;
+    local_ix += 1;
+    global_to_local.insert(raw, ix);
+    if vid_set.insert(vid) { vids_seen.push(vid); }
+    let hi_s = map_bdd_child(hi, &global_to_local);
+    let lo_s = map_bdd_child(lo, &global_to_local);
+    node_rows.push((ix, vid, hi_s, lo_s, None, None));
+  });
+
+  insert_vids(tx, sid, &vids_seen)?;
+  insert_nodes(tx, sid, &node_rows)?;
+
+  // Map root nids to snapshot-local encoding
+  let mapped_roots: Vec<(String, NID)> = roots.iter().map(|(name, nid)| {
+    let mapped = map_bdd_root(*nid, &global_to_local);
+    (name.clone(), mapped)
+  }).collect();
+  insert_roots(tx, sid, &mapped_roots)?;
+  Ok(sid)
+}
+
+fn map_bdd_child(n: NID, g2l: &HashMap<NID, usize>) -> String {
+  if n.is_const() || n.is_vid() { return format!("{}", n); }
+  let raw = n.raw();
+  let ix = g2l.get(&raw).unwrap_or_else(|| panic!("unmapped BDD child {:?}", n));
+  let local = NID::ixn(*ix);
+  format!("{}", if n.is_inv() { !local } else { local })
+}
+
+fn map_bdd_root(n: NID, g2l: &HashMap<NID, usize>) -> NID {
+  if n.is_const() || n.is_vid() { return n; }
+  let raw = n.raw();
+  let ix = g2l.get(&raw).unwrap_or_else(|| panic!("unmapped BDD root {:?}", n));
+  let local = NID::ixn(*ix);
+  if n.is_inv() { !local } else { local }
+}
+
+/// Write an ANF snapshot by walking from the given roots.
+pub fn write_anf(
+  tx: &Transaction<'_>, m: SnapshotMetaInput,
+  anf: &ANFBase, roots: &[(String, NID)],
+) -> Result<SnapshotId> {
+  ensure_snap_schema(tx)?;
+  let sid = insert_snapshot_row(tx, &m, &SnapshotKind::Anf)?;
+
+  // ANFBase stores nodes in a flat Vec<Vhl>. Walk roots to find
+  // reachable nodes and assign snapshot-local indices.
+  let mut global_to_local: HashMap<NID, usize> = HashMap::new();
+  let mut local_ix: usize = 1;
+  let mut node_rows: Vec<(usize, VID, String, String, Option<usize>, Option<usize>)> = Vec::new();
+  let mut vids_seen: Vec<VID> = Vec::new();
+  let mut vid_set = std::collections::HashSet::new();
+
+  let root_nids: Vec<NID> = roots.iter().map(|(_, n)| *n).collect();
+  anf.walk_up_each(&root_nids, &mut |nid, vid, hi, lo| {
+    let raw = nid.raw();
+    if global_to_local.contains_key(&raw) { return; }
+    if raw.is_const() || raw.is_vid() { return; }
+    let ix = local_ix;
+    local_ix += 1;
+    global_to_local.insert(raw, ix);
+    if vid_set.insert(vid) { vids_seen.push(vid); }
+    let hi_s = map_bdd_child(hi, &global_to_local);
+    let lo_s = map_bdd_child(lo, &global_to_local);
+    node_rows.push((ix, vid, hi_s, lo_s, None, None));
+  });
+
+  insert_vids(tx, sid, &vids_seen)?;
+  insert_nodes(tx, sid, &node_rows)?;
+  let mapped_roots: Vec<(String, NID)> = roots.iter().map(|(name, nid)| {
+    let mapped = map_bdd_root(*nid, &global_to_local);
+    (name.clone(), mapped)
+  }).collect();
+  insert_roots(tx, sid, &mapped_roots)?;
+  Ok(sid)
+}
+
+// -----------------------------------------------------------------------
+// Readers
+// -----------------------------------------------------------------------
+
+/// List all snapshots in the database.
+pub fn list_snapshots(conn: &Connection) -> Result<Vec<SnapshotMeta>> {
+  // If the snapshot table doesn't exist, return empty.
+  let has_table: bool = conn.query_row(
+    "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='snapshot'",
+    [], |row| row.get::<_, i64>(0),
+  )? > 0;
+  if !has_table { return Ok(Vec::new()); }
+
+  let mut stmt = conn.prepare(
+    "SELECT id, parent_id, kind, step, rv, created_at, note FROM snapshot ORDER BY id")?;
+  let rows = stmt.query_map([], |row| {
+    let id = SnapshotId(row.get::<_, i64>(0)?);
+    let parent: Option<i64> = row.get(1)?;
+    let kind_s: String = row.get(2)?;
+    let step: Option<i64> = row.get(3)?;
+    let rv_s: Option<String> = row.get(4)?;
+    let created_at: i64 = row.get(5)?;
+    let note: Option<String> = row.get(6)?;
+    Ok(SnapshotMeta {
+      id, parent: parent.map(SnapshotId),
+      kind: SnapshotKind::from_str_kind(&kind_s),
+      step: step.map(|s| s as u32),
+      rv: rv_s.map(|s| vid_from_string(&s)),
+      note, created_at,
+      vids: Vec::new(), // filled below
+      num_nodes: 0,
+    })
+  })?;
+  let mut snaps: Vec<SnapshotMeta> = rows.collect::<Result<Vec<_>>>()?;
+
+  // Fill vids and num_nodes for each snapshot
+  for snap in snaps.iter_mut() {
+    snap.vids = read_vids(conn, snap.id)?;
+    snap.num_nodes = conn.query_row(
+      "SELECT COUNT(*) FROM snapshot_node WHERE snapshot_id=?1",
+      params![snap.id.0], |row| row.get::<_, i64>(0),
+    )? as usize;
+  }
+  Ok(snaps)
+}
+
+fn read_vids(conn: &Connection, sid: SnapshotId) -> Result<Vec<VID>> {
+  let mut stmt = conn.prepare(
+    "SELECT vid FROM snapshot_vid WHERE snapshot_id=?1 ORDER BY ord")?;
+  let rows = stmt.query_map(params![sid.0], |row| {
+    let s: String = row.get(0)?;
+    Ok(vid_from_string(&s))
+  })?;
+  rows.collect()
+}
+
+fn read_roots(conn: &Connection, sid: SnapshotId) -> Result<Vec<(String, NID)>> {
+  let mut stmt = conn.prepare(
+    "SELECT name, nid FROM snapshot_root WHERE snapshot_id=?1 ORDER BY name")?;
+  let rows = stmt.query_map(params![sid.0], |row| {
+    let name: String = row.get(0)?;
+    let nid_s: String = row.get(1)?;
+    let nid = NID::from_str(&nid_s)
+      .map_err(|e| rusqlite::Error::InvalidParameterName(format!("bad root nid '{}': {}", nid_s, e)))?;
+    Ok((name, nid))
+  })?;
+  rows.collect()
+}
+
+/// Reconstruct a `VhlScaffold` from a snapshot.
+pub fn read_scaffold(
+  conn: &Connection, id: SnapshotId,
+) -> Result<(VhlScaffold, Vec<(String, NID)>)> {
+  let vids = read_vids(conn, id)?;
+  let roots = read_roots(conn, id)?;
+
+  let mut stmt = conn.prepare(
+    "SELECT ix, vid, hi, lo, irc, erc FROM snapshot_node WHERE snapshot_id=?1 ORDER BY ix")?;
+  let rows = stmt.query_map(params![id.0], |row| {
+    let ix: i64 = row.get(0)?;
+    let vid_s: String = row.get(1)?;
+    let hi_s: String = row.get(2)?;
+    let lo_s: String = row.get(3)?;
+    let irc: Option<i64> = row.get(4)?;
+    let erc: Option<i64> = row.get(5)?;
+    Ok((ix as usize, vid_s, hi_s, lo_s,
+        irc.unwrap_or(0) as usize,
+        erc.unwrap_or(0) as usize))
+  })?;
+
+  let mut nodes: Vec<(usize, Vhl, usize, usize)> = Vec::new();
+  for row in rows {
+    let (ix, vid_s, hi_s, lo_s, irc, erc) = row?;
+    let v = vid_from_string(&vid_s);
+    let hi = NID::from_str(&hi_s)
+      .map_err(|e| rusqlite::Error::InvalidParameterName(format!("bad hi '{}': {}", hi_s, e)))?;
+    let lo = NID::from_str(&lo_s)
+      .map_err(|e| rusqlite::Error::InvalidParameterName(format!("bad lo '{}': {}", lo_s, e)))?;
+    nodes.push((ix, Vhl::new(v, hi, lo), irc, erc));
+  }
+
+  let sc = VhlScaffold::from_raw(vids, &nodes);
+  Ok((sc, roots))
+}
+
+/// Load a BDD snapshot into an existing `BddBase`, returning root mappings.
+pub fn read_bdd_into(
+  conn: &Connection, id: SnapshotId, bdd: &mut BddBase,
+) -> Result<Vec<(String, NID)>> {
+  let roots_raw = read_roots(conn, id)?;
+
+  let mut stmt = conn.prepare(
+    "SELECT ix, vid, hi, lo FROM snapshot_node WHERE snapshot_id=?1 ORDER BY ix")?;
+  let rows = stmt.query_map(params![id.0], |row| {
+    let ix: i64 = row.get(0)?;
+    let vid_s: String = row.get(1)?;
+    let hi_s: String = row.get(2)?;
+    let lo_s: String = row.get(3)?;
+    Ok((ix as usize, vid_s, hi_s, lo_s))
+  })?;
+
+  // Map snapshot-local ix → global NID produced by bdd.ite().
+  let mut local_to_global: HashMap<usize, NID> = HashMap::new();
+
+  for row in rows {
+    let (ix, vid_s, hi_s, lo_s) = row?;
+    let v = vid_from_string(&vid_s);
+    let hi_raw = NID::from_str(&hi_s)
+      .map_err(|e| rusqlite::Error::InvalidParameterName(format!("bad hi '{}': {}", hi_s, e)))?;
+    let lo_raw = NID::from_str(&lo_s)
+      .map_err(|e| rusqlite::Error::InvalidParameterName(format!("bad lo '{}': {}", lo_s, e)))?;
+    let hi = resolve_local_nid(hi_raw, &local_to_global);
+    let lo = resolve_local_nid(lo_raw, &local_to_global);
+    let bv = NID::from_vid(v);
+    let nid = bdd.ite(bv, hi, lo);
+    local_to_global.insert(ix, nid);
+  }
+
+  // Remap roots
+  let roots: Vec<(String, NID)> = roots_raw.into_iter().map(|(name, nid)| {
+    (name, resolve_local_nid(nid, &local_to_global))
+  }).collect();
+  Ok(roots)
+}
+
+/// Load an ANF snapshot into an existing `ANFBase`, returning root mappings.
+pub fn read_anf_into(
+  conn: &Connection, id: SnapshotId, anf: &mut ANFBase,
+) -> Result<Vec<(String, NID)>> {
+  let roots_raw = read_roots(conn, id)?;
+
+  let mut stmt = conn.prepare(
+    "SELECT ix, vid, hi, lo FROM snapshot_node WHERE snapshot_id=?1 ORDER BY ix")?;
+  let rows = stmt.query_map(params![id.0], |row| {
+    let ix: i64 = row.get(0)?;
+    let vid_s: String = row.get(1)?;
+    let hi_s: String = row.get(2)?;
+    let lo_s: String = row.get(3)?;
+    Ok((ix as usize, vid_s, hi_s, lo_s))
+  })?;
+
+  let mut local_to_global: HashMap<usize, NID> = HashMap::new();
+
+  for row in rows {
+    let (ix, vid_s, hi_s, lo_s) = row?;
+    let v = vid_from_string(&vid_s);
+    let hi_raw = NID::from_str(&hi_s)
+      .map_err(|e| rusqlite::Error::InvalidParameterName(format!("bad hi '{}': {}", hi_s, e)))?;
+    let lo_raw = NID::from_str(&lo_s)
+      .map_err(|e| rusqlite::Error::InvalidParameterName(format!("bad lo '{}': {}", lo_s, e)))?;
+    let hi = resolve_local_nid(hi_raw, &local_to_global);
+    let lo = resolve_local_nid(lo_raw, &local_to_global);
+    let nid = anf.insert_vhl(v, hi, lo);
+    local_to_global.insert(ix, nid);
+  }
+
+  let roots: Vec<(String, NID)> = roots_raw.into_iter().map(|(name, nid)| {
+    (name, resolve_local_nid(nid, &local_to_global))
+  }).collect();
+  Ok(roots)
+}
+
+/// Resolve a snapshot-local NID: if it's an `@N` (ixn), look up N in the map.
+/// Constants and vid-literals pass through unchanged.
+fn resolve_local_nid(n: NID, l2g: &HashMap<usize, NID>) -> NID {
+  if n.is_const() || n.is_vid() { return n; }
+  if n.is_ixn() {
+    let ix = n.raw().idx();
+    let global = l2g.get(&ix).unwrap_or_else(|| panic!("unmapped local ix {} in snapshot", ix));
+    if n.is_inv() { !*global } else { *global }
+  } else {
+    // vid.idx form — shouldn't appear in snapshot data, but pass through.
+    n
+  }
+}
+
+// -----------------------------------------------------------------------
+// Path-based convenience wrappers
+// -----------------------------------------------------------------------
+
+/// Write a scaffold snapshot to a (possibly existing) SQLite file.
+pub fn write_scaffold_to_path<P: AsRef<Path>>(
+  path: P, m: SnapshotMetaInput, sc: &VhlScaffold, roots: &[(String, NID)],
+) -> Result<SnapshotId> {
+  let mut conn = Connection::open(path)?;
+  // Ensure the AST meta table exists so we can write snap.fmt.version
+  crate::sql::ensure_schema_pub(&conn)?;
+  let tx = conn.transaction()?;
+  let sid = write_scaffold(& tx, m, sc, roots)?;
+  tx.commit()?;
+  Ok(sid)
+}
+
+/// Read a scaffold snapshot from a SQLite file.
+pub fn read_scaffold_from_path<P: AsRef<Path>>(
+  path: P, id: SnapshotId,
+) -> Result<(VhlScaffold, Vec<(String, NID)>)> {
+  let conn = Connection::open(path)?;
+  read_scaffold(&conn, id)
+}
+
+/// Write a BDD snapshot to a (possibly existing) SQLite file.
+pub fn write_bdd_to_path<P: AsRef<Path>>(
+  path: P, m: SnapshotMetaInput, bdd: &BddBase, roots: &[(String, NID)],
+) -> Result<SnapshotId> {
+  let mut conn = Connection::open(path)?;
+  crate::sql::ensure_schema_pub(&conn)?;
+  let tx = conn.transaction()?;
+  let sid = write_bdd(&tx, m, bdd, roots)?;
+  tx.commit()?;
+  Ok(sid)
+}
+
+/// Write an ANF snapshot to a (possibly existing) SQLite file.
+pub fn write_anf_to_path<P: AsRef<Path>>(
+  path: P, m: SnapshotMetaInput, anf: &ANFBase, roots: &[(String, NID)],
+) -> Result<SnapshotId> {
+  let mut conn = Connection::open(path)?;
+  crate::sql::ensure_schema_pub(&conn)?;
+  let tx = conn.transaction()?;
+  let sid = write_anf(&tx, m, anf, roots)?;
+  tx.commit()?;
+  Ok(sid)
+}
+
+// -----------------------------------------------------------------------
+// Tests
+// -----------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+  use super::*;
+  use crate::vid::VID;
+  use crate::nid;
+  #[allow(unused_imports)]
+  use crate::vhl::Vhl;
+  use crate::base::Base;
+
+  fn in_memory_conn() -> Connection {
+    let mut conn = Connection::open_in_memory().unwrap();
+    { let tx = conn.transaction().unwrap();
+      crate::sql::ensure_schema_tx(&tx).unwrap();
+      ensure_snap_schema(&tx).unwrap();
+      tx.commit().unwrap(); }
+    conn
+  }
+
+  #[test]
+  fn schema_idempotent() {
+    let mut conn = in_memory_conn();
+    // Running ensure_snap_schema again should be fine
+    let tx = conn.transaction().unwrap();
+    ensure_snap_schema(&tx).unwrap();
+    tx.commit().unwrap();
+    let snaps = list_snapshots(&conn).unwrap();
+    assert!(snaps.is_empty());
+  }
+
+  #[test]
+  fn scaffold_roundtrip() {
+    let mut conn = in_memory_conn();
+
+    // Build a small scaffold: two vars, one internal node.
+    let mut sc = VhlScaffold::new();
+    sc.push(VID::var(0));
+    sc.push(VID::var(1));
+    // x1 branches to x0 (hi) and O (lo)
+    let x0_nid = sc.add(VID::var(0), nid::I, nid::O, false);
+    let root = sc.add(VID::var(1), x0_nid, nid::O, true);
+
+    let tx = conn.transaction().unwrap();
+    let sid = write_scaffold(&tx, SnapshotMetaInput {
+      parent: None, step: Some(0), rv: None, note: Some("test".into()),
+    }, &sc, &[("root".into(), root)]).unwrap();
+    tx.commit().unwrap();
+
+    // List should show one snapshot
+    let snaps = list_snapshots(&conn).unwrap();
+    assert_eq!(snaps.len(), 1);
+    assert_eq!(snaps[0].kind, SnapshotKind::Scaffold);
+    assert_eq!(snaps[0].step, Some(0));
+    assert_eq!(snaps[0].vids.len(), 2);
+
+    // Read it back
+    let (sc2, roots2) = read_scaffold(&conn, sid).unwrap();
+    assert_eq!(sc2.vids(), sc.vids());
+    assert_eq!(sc2.num_nodes(), sc.num_nodes());
+    assert_eq!(roots2.len(), 1);
+    assert_eq!(roots2[0].0, "root");
+    assert_eq!(roots2[0].1, root);
+
+    // Verify structure matches
+    let orig_nodes = sc.iter_nodes();
+    let loaded_nodes = sc2.iter_nodes();
+    assert_eq!(orig_nodes.len(), loaded_nodes.len());
+    for (a, b) in orig_nodes.iter().zip(loaded_nodes.iter()) {
+      assert_eq!(a.0, b.0, "ix mismatch");
+      assert_eq!(a.1, b.1, "vhl mismatch");
+      assert_eq!(a.2, b.2, "irc mismatch");
+      assert_eq!(a.3, b.3, "erc mismatch");
+    }
+  }
+
+  #[test]
+  fn bdd_roundtrip() {
+    let mut conn = in_memory_conn();
+    let mut bdd = BddBase::new();
+    let x0 = NID::from_vid(VID::var(0));
+    let x1 = NID::from_vid(VID::var(1));
+    let root = bdd.and(x0, x1); // x0 AND x1
+
+    let tx = conn.transaction().unwrap();
+    let sid = write_bdd(&tx, SnapshotMetaInput {
+      parent: None, step: None, rv: None, note: None,
+    }, &bdd, &[("root".into(), root)]).unwrap();
+    tx.commit().unwrap();
+
+    // Load into a fresh BDD
+    let mut bdd2 = BddBase::new();
+    let roots2 = read_bdd_into(&conn, sid, &mut bdd2).unwrap();
+    assert_eq!(roots2.len(), 1);
+    let root2 = roots2[0].1;
+
+    // Verify extensional equivalence: enumerate all 4 assignments
+    for bits in 0u32..4 {
+      let v0 = (bits & 1) != 0;
+      let v1 = (bits >> 1) != 0;
+      let r1 = eval_bdd(&mut bdd, root, &[(VID::var(0), v0), (VID::var(1), v1)]);
+      let r2 = eval_bdd(&mut bdd2, root2, &[(VID::var(0), v0), (VID::var(1), v1)]);
+      assert_eq!(r1, r2, "mismatch at bits={:02b}", bits);
+    }
+  }
+
+  #[test]
+  fn anf_roundtrip() {
+    let mut conn = in_memory_conn();
+    let mut anf = ANFBase::new();
+    let x0 = NID::from_vid(VID::var(0));
+    let x1 = NID::from_vid(VID::var(1));
+    let root = anf.xor(x0, x1); // x0 XOR x1
+
+    let tx = conn.transaction().unwrap();
+    let sid = write_anf(&tx, SnapshotMetaInput {
+      parent: None, step: None, rv: None, note: None,
+    }, &anf, &[("root".into(), root)]).unwrap();
+    tx.commit().unwrap();
+
+    let mut anf2 = ANFBase::new();
+    let roots2 = read_anf_into(&conn, sid, &mut anf2).unwrap();
+    assert_eq!(roots2.len(), 1);
+    let root2 = roots2[0].1;
+
+    // Verify extensional equivalence
+    for bits in 0u32..4 {
+      let v0 = (bits & 1) != 0;
+      let v1 = (bits >> 1) != 0;
+      let r1 = eval_anf(&mut anf, root, &[(VID::var(0), v0), (VID::var(1), v1)]);
+      let r2 = eval_anf(&mut anf2, root2, &[(VID::var(0), v0), (VID::var(1), v1)]);
+      assert_eq!(r1, r2, "mismatch at bits={:02b}", bits);
+    }
+  }
+
+  #[test]
+  fn snapshot_chain() {
+    let mut conn = in_memory_conn();
+    let mut sc = VhlScaffold::new();
+    sc.push(VID::var(0));
+    let root = sc.add(VID::var(0), nid::I, nid::O, true);
+
+    let tx = conn.transaction().unwrap();
+    let s1 = write_scaffold(&tx, SnapshotMetaInput {
+      parent: None, step: Some(0), rv: None, note: None,
+    }, &sc, &[("root".into(), root)]).unwrap();
+    let _s2 = write_scaffold(&tx, SnapshotMetaInput {
+      parent: Some(s1), step: Some(1), rv: Some(VID::var(0)), note: None,
+    }, &sc, &[("root".into(), root)]).unwrap();
+    tx.commit().unwrap();
+
+    let snaps = list_snapshots(&conn).unwrap();
+    assert_eq!(snaps.len(), 2);
+    assert_eq!(snaps[0].parent, None);
+    assert_eq!(snaps[1].parent, Some(s1));
+  }
+
+  #[test]
+  fn backward_compat_ast_only() {
+    // A file with only AST tables: list_snapshots should return empty.
+    let conn = Connection::open_in_memory().unwrap();
+    // We don't even create snap tables — just check it doesn't crash.
+    let snaps = list_snapshots(&conn).unwrap();
+    assert!(snaps.is_empty());
+  }
+
+  // -- test helpers --
+
+  fn eval_bdd(bdd: &mut BddBase, root: NID, env: &[(VID, bool)]) -> bool {
+    let mut cur = root;
+    for &(v, val) in env {
+      cur = if val { bdd.when_hi(v, cur) } else { bdd.when_lo(v, cur) };
+    }
+    assert!(cur.is_const(), "bdd didn't collapse: {:?}", cur);
+    cur == nid::I
+  }
+
+  fn eval_anf(anf: &mut ANFBase, root: NID, env: &[(VID, bool)]) -> bool {
+    let mut cur = root;
+    for &(v, val) in env {
+      cur = if val { anf.when_hi(v, cur) } else { anf.when_lo(v, cur) };
+    }
+    assert!(cur.is_const(), "anf didn't collapse: {:?}", cur);
+    cur == nid::I
+  }
+}

--- a/src/swap.rs
+++ b/src/swap.rs
@@ -76,7 +76,10 @@ const VHL_NEW:Vhl = Vhl{ v: VID::top(), hi:nid::O, lo:nid::O };
 pub struct IxRc { ix:NID, irc: usize, erc: usize }
 impl IxRc {
   fn rc(&self)->usize { self.irc + self.erc }
-  fn add(&mut self, count:i64) { self.irc = (self.irc as i64 + count) as usize; }}
+  fn add(&mut self, count:i64) { self.irc = (self.irc as i64 + count) as usize; }
+  pub fn ix(&self)->NID { self.ix }
+  pub fn irc(&self)->usize { self.irc }
+  pub fn erc(&self)->usize { self.erc }}
 
 /**
 We need to map:
@@ -252,6 +255,62 @@ impl VhlScaffold {
   /// have to walk from a specific root.
   pub fn num_nodes(&self)->usize {
     self.rows.values().map(|r| r.hm.len()).sum()
+  }
+
+  /// Is the scaffold in a mid-regroup state? If true, callers should not
+  /// attempt to serialize it — refcount deltas are held in `drcd` and the
+  /// next valid snapshot point is after the regroup finishes.
+  pub fn is_mid_regroup(&self)->bool { !self.locked.is_empty() }
+
+  /// Iterate over every allocated node in the scaffold in scaffold-row
+  /// order (bottom to top). Each item is `(ix, vhl, irc, erc)` where
+  /// `ix` is the slot inside `vhls` (so `NID::ixn(ix)` refers to the
+  /// node), and `irc` / `erc` are the internal and external refcounts.
+  /// Skips the sentinel slot 0 and any garbage-collected rows. Panics if
+  /// the scaffold is mid-regroup.
+  pub fn iter_nodes(&self)->Vec<(usize, Vhl, usize, usize)> {
+    assert!(
+      !self.is_mid_regroup(),
+      "iter_nodes called on a mid-regroup scaffold: locked={:?}",
+      self.locked);
+    let mut out: Vec<(usize, Vhl, usize, usize)> = Vec::new();
+    for (ri, rv) in self.vids.iter().enumerate() {
+      let Some(row) = self.rows.get(rv) else { continue };
+      for (hl, ixrc) in row.hm.iter() {
+        let ix = ixrc.ix.idx();
+        let vhl = Vhl{ v:*rv, hi: hl.hi, lo: hl.lo };
+        let _ = ri; // row order is implicit in vid order; we ship rows in vid order
+        out.push((ix, vhl, ixrc.irc, ixrc.erc));
+      }
+    }
+    // order by scaffold index so downstream consumers can reconstruct
+    // vhls[] by ix position directly.
+    out.sort_by_key(|(ix, _, _, _)| *ix);
+    out
+  }
+
+  /// Rebuild a `VhlScaffold` from raw data: a bottom-to-top vid list
+  /// plus node tuples `(ix, vhl, irc, erc)` where `ix` is the slot
+  /// inside `vhls` and refcounts are stored verbatim (no recursive
+  /// propagation). Used by the SQL snapshot loader.
+  ///
+  /// This does not validate the input; the caller is responsible for
+  /// ensuring refcounts are consistent. For a stricter mode, run
+  /// `validate` on the result in tests.
+  pub fn from_raw(vids: Vec<VID>, nodes: &[(usize, Vhl, usize, usize)]) -> Self {
+    let mut sc = VhlScaffold::new();
+    for v in vids { sc.push(v); }
+    // Size `vhls` to hold every stored ix, filling unused slots with the
+    // VHL_O sentinel so `get(ixn(k))` returns None for unallocated nodes.
+    let max_ix = nodes.iter().map(|(ix, _, _, _)| *ix).max().unwrap_or(0);
+    while sc.vhls.len() <= max_ix { sc.vhls.push(VHL_O); }
+    for &(ix, vhl, irc, erc) in nodes {
+      assert!(ix > 0, "slot 0 is reserved for VHL_O sentinel");
+      sc.vhls[ix] = vhl;
+      let row = sc.rows.entry(vhl.v).or_insert_with(VhlRow::new);
+      row.hm.insert(vhl.hilo(), IxRc{ ix: NID::ixn(ix), irc, erc });
+    }
+    sc
   }
 
   /// return the vid immediately above v in the scaffold, or None
@@ -1343,6 +1402,20 @@ impl SwapSolver {
   /// need to copy this solver's BDD into another base alongside BDDs from
   /// other scaffolds (e.g. `scaffold().copy_to_bdd_keep_vids(...)`).
   pub fn scaffold(&self) -> &VhlScaffold { &self.dst }
+
+  /// Current top node in the destination scaffold.
+  pub fn dx(&self) -> NID { self.dx }
+
+  /// The variable most recently substituted (or NOV if none).
+  pub fn rv(&self) -> VID { self.rv }
+
+  /// Construct a `SwapSolver` whose destination is an already-built
+  /// scaffold with its top node at `dx`. The source scaffold is empty
+  /// and `rv` is unset. Used by the SQL snapshot loader to resume a
+  /// solver between substitution steps.
+  pub fn from_parts(dst: VhlScaffold, dx: NID) -> Self {
+    SwapSolver{ dst, dx, rv: NOV, src: VhlScaffold::new(), sx: nid::O }
+  }
 
   /// Arrange the two scaffolds so that their variable orders match.
   ///  1. vids shared between src and dst (set n) are above rv


### PR DESCRIPTION
## Summary

Addresses bex#6 ("Allow loading and saving intermediate state for VhlSwarm"). Instead of tackling the hard path (serializing live `Wip { parts, deps }` + channels mid-computation), this takes the pragmatic approach we discussed: **snapshot the completed BDD between substitution steps**, preserving the `SwapSolver` scaffold's changing variable permutation, so a solver can resume or replay mid-problem.

Three landing pieces:

### 1. `sql_snap` module — snapshot persistence

Four new SQLite tables coexist with the existing AST schema (which is untouched):

```
snapshot       (id, parent_id, kind, step, rv, created_at, note)
snapshot_vid   (snapshot_id, ord, vid)        — variable permutation
snapshot_node  (snapshot_id, ix, vid, hi, lo, irc, erc)
snapshot_root  (snapshot_id, name, nid)
```

Public API in `bex::sql_snap`:

```rust
write_scaffold / write_bdd / write_anf     // take &Transaction + &T + roots
read_scaffold / read_bdd_into / read_anf_into
list_snapshots
ensure_snap_schema
```

Plus path-based convenience wrappers. The `rusqlite` dependency lives here, **not** in `swap.rs`.

New accessors on existing types (no behavior changes):
- `VhlScaffold::iter_nodes`, `from_raw`, `is_mid_regroup`
- `SwapSolver::dx`, `rv`, `from_parts`
- `ANFBase::nodes`, `tags`, `tags_mut`, `insert_vhl`
- `sql::ensure_schema_pub`, `ensure_schema_tx` — so callers can share a transaction between AST export and snapshot writes

Variable permutation is first-class: scaffold snapshots round-trip `vids()` byte-identical. This is the piece that `copy_to_bdd_keep_vids` loses when flattening a `SwapSolver` into a plain `BddBase`.

### 2. Solver binaries

| Binary | Purpose |
|--------|---------|
| `bex-mkproblem -p N -o file.sdb` | Generate an AST `.sdb` for primorial(N) factoring |
| `bex-solve --solver swap\|bdd\|anf --save-every N file.sdb` | Drive the substitution solve loop with auto-snapshot after every N steps |
| `bex-sdb list/info/dump/ast/replay` | Inspect `.sdb` files |

`bex-solve` supports `--resume <snap-id>` (scaffold resume implemented; BDD/ANF resume follow the same pattern), `--timeout <secs>`, and `-o <output.sdb>` for writing snapshots to a different file.

End-to-end verified:

```
$ bex-mkproblem -p 2 -o /tmp/p2.sdb
primorial(2) = 6
wrote /tmp/p2.sdb (462 AST nodes)

$ bex-solve --solver swap --save-every 50 /tmp/p2.sdb
loaded AST: 462 nodes, top=@1CD
sorted AST: 461 nodes, 461 steps to solve
... 461 steps ...
saved final snapshot 11
done: 461 steps in 2.357s, result=@4

$ bex-sdb list /tmp/p2.sdb
  id  parent      kind  step      rv  #nodes  #vids  note
   1       -  scaffold     9    v1C3      13      9  -
   2       -  scaffold    49    v19B      60     17  -
  ...
  11      10  scaffold   460       -      22     16  final
```

### 3. Internal change: `solve::refine_one` is now `pub`

So external drivers can reuse the same substitution primitive the library's `solve()` uses.

## Design decisions

- **Additive schema** — AST tables untouched; existing `.sdb` files load unchanged through `import_raw_ast_from_conn`. Files without snapshot tables return `list_snapshots() -> []` cleanly.
- **Chained snapshots via `parent_id`** — supports both "one DB = full replay trace" and "overwrite as you go" patterns.
- **Scaffold-preserving** — snapshots record the scaffold's `Vec<VID>` permutation, so `SwapSolver` round-trips without flattening.
- **Scaffold vs BDD vs ANF** — distinguished by a `kind` column; ANF uses its XOR-of-products semantics intact.
- **Refcount storage** — `snapshot_node.irc/erc` nullable; scaffolds store them, BDD/ANF emit NULL (recomputed at load time if needed).
- **Separate `tag` table unchanged** — the existing AST `tag` table stays pure-AST; named roots per snapshot go in the new `snapshot_root` table.

## What this does NOT do

- Does **not** serialize live `Wip { parts, deps }` mid-computation. That's the real bex#6 endgame (plus WIP-channel reconstruction) and is intentionally deferred.
- Does **not** preserve the scaffold's `locked`/`drcd` mid-regroup state — `write_scaffold` asserts `!is_mid_regroup()`. Callers save between `subst` calls, not during one. This matches the known-safe boundary in the existing solve loop.

## Test plan

- [x] `cargo test` — all 167 lib tests pass, no regressions
- [x] 6 new tests in `sql_snap`: schema idempotency, scaffold round-trip, BDD round-trip (extensional equivalence), ANF round-trip, snapshot chain, backward compat with AST-only files
- [x] End-to-end: `bex-mkproblem` → `bex-solve` → `bex-sdb list/replay` on primorial(2) (461 steps, 11 chained snapshots)
- [x] `cargo build --all-targets` clean (zero warnings)
- [x] Clippy clean for new files (pre-existing warnings in swap.rs/bdd.rs not touched)

## Files

Created:
- `src/sql_snap.rs` (writers, readers, schema, 6 tests)
- `src/bin/bex-sdb.rs` (inspection CLI)
- `src/bin/bex-mkproblem.rs` (primorial AST generator)
- `src/bin/bex-solve.rs` (solver driver with auto-snapshot)

Modified:
- `src/swap.rs` — VhlScaffold/SwapSolver accessors
- `src/anf.rs` — ANFBase accessors
- `src/sql.rs` — public `ensure_schema_*` helpers
- `src/solve.rs` — `refine_one` made pub
- `src/lib.rs` — `sql_snap` module declaration
- `Cargo.toml` — three new `[[bin]]` entries
- `CHANGELOG.md` — documented under 0.4.0

https://claude.ai/code/session_017ZXBnEHjP12ZjSyro3uA26