### PR TITLE
Performance + correctness fixes for bdd-benchmark integration (bex#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ Bex is a rust crate for working with binary expressions.
   - `ZddSetIterator` for native family enumeration; `ZddSolIterator` for
     Boolean solution enumeration via BDD conversion.
   - Graphviz rendering via `dot`.
+- **Direct single-threaded ITE path for `BddBase`.** Opt in with
+  `BddBase::set_direct_ite(true)` (or `bex_bdd_set_direct_ite(bdd, true)` from C) to
+  bypass swarm dispatch and recurse directly with a local `FxHashMap` computed table.
+  Designed for workloads that build BDDs bottom-up via many small sequential ITE
+  calls, where channel-dispatch overhead dominates. Default is unchanged (swarm).
+  - Reduced the `bdd-benchmark` queens N=8 runtime from "hangs" to ~580 ms in the
+    bdd-benchmark adapter; unblocks tic-tac-toe, hamiltonian, and game-of-life too.
+- New FFI `bex_swap_copy_to_bdd(swap, bdd, n)` so C callers can transfer a
+  swap-solver result into a separate `BddBase` and use the normal
+  `bex_bdd_node_count` / `bex_bdd_solution_count` on it.
+- `VhlSwarm` now exposes `get_done` / `put_done` / `vhl_to_nid` so callers can
+  check the shared computed table or construct nodes without dispatching a job.
+
+### Bug fixes
+- `tbl::merge_small` wrote past the end of a 5-element array before returning
+  `None` on 6-variable ITEs, causing panics in the truth-table fast path. The
+  `len > 5` guards are now `len >= 5`.
+- `tbl::nid_to_small` accepted real-variable NIDs with an index >= `MAX_VAR`
+  and fed them into the combinatorial encoder, which panicked with an array
+  bounds error. Now it returns `None` so the caller falls back to the regular
+  BDD path. This unblocked the `bdd-benchmark` hamiltonian workload, which
+  allocates more than 110 variables.
 
 - **Table NIDs with named variables.** Functions of up to 5 input variables are now stored
   directly in the NID as a truth table, with the variable set encoded using a combinatorial

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -129,6 +129,19 @@ pub extern "C" fn bex_bdd_new() -> *mut bex_bdd_t {
     }))
 }
 
+/// Opt into direct single-threaded ITE recursion for this BDD base.
+/// Best for bottom-up workloads; avoids swarm dispatch overhead.
+#[no_mangle]
+pub extern "C" fn bex_bdd_set_direct_ite(bdd: *mut bex_bdd_t, on: bool) {
+    ffi_guard((), move || unsafe {
+        let Some(bdd_ref) = bdd.as_ref() else { return };
+        let base_ptr = bdd_ref.base as *mut Arc<Mutex<BddBase>>;
+        let Some(base_arc) = base_ptr.as_ref() else { return };
+        let Ok(mut base) = base_arc.lock() else { return };
+        base.set_direct_ite(on);
+    })
+}
+
 #[no_mangle]
 pub extern "C" fn bex_bdd_free(bdd: *mut bex_bdd_t) {
     if !bdd.is_null() {

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -310,6 +310,31 @@ pub extern "C" fn bex_swapsolve(ast: *mut bex_ast_t, swap: *mut bex_swap_t, n: b
     })
 }
 
+/// Copy the swap solver's result into the given BddBase and return the
+/// translated NID.  Needed before calling bex_bdd_node_count /
+/// bex_bdd_solution_count on a swap-solver result, because those
+/// functions index into `bdd`'s storage rather than the swap solver's.
+#[no_mangle]
+pub extern "C" fn bex_swap_copy_to_bdd(
+    swap: *mut bex_swap_t,
+    bdd: *mut bex_bdd_t,
+    n: bex_nid_t,
+) -> bex_nid_t {
+    ffi_guard(ffi_nid_default(), move || unsafe {
+        let Some(swap_ref) = swap.as_ref() else { return ffi_nid_default() };
+        let Some(bdd_ref)  = bdd.as_ref()  else { return ffi_nid_default() };
+        let swap_ptr = swap_ref.base as *mut Arc<Mutex<SwapSolver>>;
+        let bdd_ptr  = bdd_ref.base  as *mut Arc<Mutex<BddBase>>;
+        let Some(swap_arc) = swap_ptr.as_ref() else { return ffi_nid_default() };
+        let Some(bdd_arc)  = bdd_ptr.as_ref()  else { return ffi_nid_default() };
+        let Ok(swap_solver) = swap_arc.lock() else { return ffi_nid_default() };
+        let Ok(mut bdd_base) = bdd_arc.lock() else { return ffi_nid_default() };
+        let nid = NID::_from_u64(n.nid);
+        let out = swap_solver.scaffold().copy_to_bdd(&mut bdd_base, &[nid]);
+        bex_nid_t { nid: out[0]._to_u64() }
+    })
+}
+
 #[no_mangle]
 pub extern "C" fn bex_is_vid(n: bex_nid_t) -> bool {
     ffi_guard(ffi_bool_default(), move || {

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -98,15 +98,28 @@ pub struct BddBase {
   /// allows us to give user-friendly names to specific nodes in the base.
   pub tags: HashMap<String, NID>,
   pub swarm: BddSwarm, // TODO: nopub
-  /// fast single-threaded ITE cache, avoids DashMap overhead for direct recursion
+  /// when true, use direct single-threaded recursion for ITE with a local
+  /// FxHashMap cache, bypassing swarm dispatch overhead. Best for workloads
+  /// that build BDDs bottom-up with many small, sequential operations (e.g.
+  /// the bdd-benchmark queens/tic-tac-toe tests). Default: false (use swarm).
+  direct_ite: bool,
+  /// fast local cache used when `direct_ite` is enabled.
   ite_cache: fxhash::FxHashMap<NormIteKey, NID>}
 
 impl BddBase {
 
-  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), ite_cache:fxhash::FxHashMap::default()}}
+  pub fn new()->BddBase {
+    BddBase{swarm: BddSwarm::new(), tags:HashMap::new(),
+      direct_ite:false, ite_cache:fxhash::FxHashMap::default()}}
 
   pub fn new_with_threads(n:usize)->BddBase {
-    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new(), ite_cache:fxhash::FxHashMap::default()}}
+    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new(),
+      direct_ite:false, ite_cache:fxhash::FxHashMap::default()}}
+
+  /// Opt into direct single-threaded ITE recursion. This avoids the swarm
+  /// channel-dispatch overhead at the cost of giving up intra-operation
+  /// parallelism. Useful for bottom-up BDD construction workloads.
+  pub fn set_direct_ite(&mut self, on:bool) { self.direct_ite = on; }
 
   /// return (hi, lo) pair for the given nid. used internally
   #[inline] fn tup(&self, n:NID)->(NID,NID) { self.swarm.tup(n) }
@@ -126,9 +139,24 @@ impl BddBase {
   pub fn  gt(&mut self, x:NID, y:NID)->NID { self.ite(x, !y, O) }
   pub fn  lt(&mut self, x:NID, y:NID)->NID { self.ite(x, O, y) }
 
-  /// all-purpose node creation/lookup.
-  /// Uses direct recursion with a fast local FxHashMap cache.
+  /// all-purpose node creation/lookup. Dispatches to the swarm by default,
+  /// or to direct single-threaded recursion when `set_direct_ite(true)` is set.
   #[inline] pub fn ite(&mut self, f:NID, g:NID, h:NID)->NID {
+    if self.direct_ite { return self.ite_local(f, g, h); }
+    match ITE::norm(f,g,h) {
+      Norm::Nid(n) => n,
+      Norm::Ite(ite) => {
+        if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return r; }
+        if let Some(r) = self.swarm.get_done(&ite) { return r; }
+        self.swarm.run_swarm_job(ite) }
+      Norm::Not(ite) => {
+        if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return !r; }
+        if let Some(r) = self.swarm.get_done(&ite) { return !r; }
+        !self.swarm.run_swarm_job(ite) }}}
+
+  /// Direct single-threaded ITE with a fast local FxHashMap cache.
+  /// Avoids the swarm channel-dispatch overhead per call.
+  #[inline] fn ite_local(&mut self, f:NID, g:NID, h:NID)->NID {
     match ITE::norm(f,g,h) {
       Norm::Nid(n) => n,
       Norm::Ite(ite) => {
@@ -144,17 +172,15 @@ impl BddBase {
         self.ite_cache.insert(ite, r);
         !r }}}
 
-  /// Direct recursive ITE without swarm dispatch.
-  /// Shannon-decomposes on the top variable, recurses, then creates the node.
+  /// Shannon-decompose an already-normalized ITE and build its result node.
   fn ite_direct(&mut self, ite:ITE)->NID {
     let ITE { i, t, e } = ite;
     let v = ite.top_vid();
     let (hi_i, lo_i) = if v == i.vid() { self.tup(i) } else { (i, i) };
     let (hi_t, lo_t) = if v == t.vid() { self.tup(t) } else { (t, t) };
     let (hi_e, lo_e) = if v == e.vid() { self.tup(e) } else { (e, e) };
-    let hi = self.ite(hi_i, hi_t, hi_e);
-    let lo = self.ite(lo_i, lo_t, lo_e);
-    // Create/lookup the node for (v, hi, lo) via normalization
+    let hi = self.ite_local(hi_i, hi_t, hi_e);
+    let lo = self.ite_local(lo_i, lo_t, lo_e);
     match ITE::norm(NID::from_vid(v), hi, lo) {
       Norm::Nid(n) => n,
       Norm::Ite(ite2) => self.swarm.vhl_to_nid(ite2.0.i.vid(), ite2.0.t, ite2.0.e),
@@ -367,7 +393,9 @@ impl Default for BddBase { fn default() -> Self { Self::new() }}
 
 impl Base for BddBase {
 
-  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), ite_cache:fxhash::FxHashMap::default()}}
+  fn new()->BddBase {
+    BddBase{swarm: BddSwarm::new(), tags:HashMap::new(),
+      direct_ite:false, ite_cache:fxhash::FxHashMap::default()}}
 
   /// nid of y when x is high
   fn when_hi(&mut self, x:VID, y:NID)->NID {

--- a/src/bdd.rs
+++ b/src/bdd.rs
@@ -97,14 +97,16 @@ impl ITE {
 pub struct BddBase {
   /// allows us to give user-friendly names to specific nodes in the base.
   pub tags: HashMap<String, NID>,
-  pub swarm: BddSwarm} // TODO: nopub
+  pub swarm: BddSwarm, // TODO: nopub
+  /// fast single-threaded ITE cache, avoids DashMap overhead for direct recursion
+  ite_cache: fxhash::FxHashMap<NormIteKey, NID>}
 
 impl BddBase {
 
-  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new()}}
+  pub fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), ite_cache:fxhash::FxHashMap::default()}}
 
   pub fn new_with_threads(n:usize)->BddBase {
-    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new()}}
+    BddBase{swarm: BddSwarm::new_with_threads(n), tags:HashMap::new(), ite_cache:fxhash::FxHashMap::default()}}
 
   /// return (hi, lo) pair for the given nid. used internally
   #[inline] fn tup(&self, n:NID)->(NID,NID) { self.swarm.tup(n) }
@@ -113,7 +115,7 @@ impl BddBase {
     let (hi, lo) = self.tup(n); (n.vid(), hi, lo) }
 
   // clear all data from the cache (mostly for benchmarks)
-  pub fn reset(&mut self) { self.swarm.reset(); }
+  pub fn reset(&mut self) { self.swarm.reset(); self.ite_cache = fxhash::FxHashMap::default(); }
 
   pub fn len(&self)->usize { self.swarm.len() }
   #[must_use] pub fn is_empty(&self) -> bool { self.len() == 0 }
@@ -124,16 +126,39 @@ impl BddBase {
   pub fn  gt(&mut self, x:NID, y:NID)->NID { self.ite(x, !y, O) }
   pub fn  lt(&mut self, x:NID, y:NID)->NID { self.ite(x, O, y) }
 
-  /// all-purpose node creation/lookup
+  /// all-purpose node creation/lookup.
+  /// Uses direct recursion with a fast local FxHashMap cache.
   #[inline] pub fn ite(&mut self, f:NID, g:NID, h:NID)->NID {
     match ITE::norm(f,g,h) {
       Norm::Nid(n) => n,
       Norm::Ite(ite) => {
         if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return r; }
-        self.swarm.run_swarm_job(ite) }
+        if let Some(&r) = self.ite_cache.get(&ite) { return r; }
+        let r = self.ite_direct(ite.0);
+        self.ite_cache.insert(ite, r);
+        r }
       Norm::Not(ite) => {
         if let Some(r) = crate::tbl::table_ite(ite.0.i, ite.0.t, ite.0.e) { return !r; }
-        !self.swarm.run_swarm_job(ite) }}}
+        if let Some(&r) = self.ite_cache.get(&ite) { return !r; }
+        let r = self.ite_direct(ite.0);
+        self.ite_cache.insert(ite, r);
+        !r }}}
+
+  /// Direct recursive ITE without swarm dispatch.
+  /// Shannon-decomposes on the top variable, recurses, then creates the node.
+  fn ite_direct(&mut self, ite:ITE)->NID {
+    let ITE { i, t, e } = ite;
+    let v = ite.top_vid();
+    let (hi_i, lo_i) = if v == i.vid() { self.tup(i) } else { (i, i) };
+    let (hi_t, lo_t) = if v == t.vid() { self.tup(t) } else { (t, t) };
+    let (hi_e, lo_e) = if v == e.vid() { self.tup(e) } else { (e, e) };
+    let hi = self.ite(hi_i, hi_t, hi_e);
+    let lo = self.ite(lo_i, lo_t, lo_e);
+    // Create/lookup the node for (v, hi, lo) via normalization
+    match ITE::norm(NID::from_vid(v), hi, lo) {
+      Norm::Nid(n) => n,
+      Norm::Ite(ite2) => self.swarm.vhl_to_nid(ite2.0.i.vid(), ite2.0.t, ite2.0.e),
+      Norm::Not(ite2) => !self.swarm.vhl_to_nid(ite2.0.i.vid(), ite2.0.t, ite2.0.e) }}
 
 
   /// swap input variables x and y within bdd n
@@ -342,7 +367,7 @@ impl Default for BddBase { fn default() -> Self { Self::new() }}
 
 impl Base for BddBase {
 
-  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new()}}
+  fn new()->BddBase { BddBase{swarm: BddSwarm::new(), tags:HashMap::new(), ite_cache:fxhash::FxHashMap::default()}}
 
   /// nid of y when x is high
   fn when_hi(&mut self, x:VID, y:NID)->NID {

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -51,6 +51,9 @@ impl SmallTbl {
     Some(SmallTbl { tbl: if n == I { 0xFFFFFFFF } else { 0 }, vars: [0;5], arity: 0 })
   } else if n.is_var() {   // real variables only
     let vi = n.vid().var_ix() as u32;
+    // Truth-table NIDs are restricted to variable indices < MAX_VAR;
+    // anything else must fall back to the BDD path.
+    if (vi as usize) >= crate::comb::MAX_VAR { return None; }
     let tbl = if n.is_inv() { 0b10u32 } else { 0b01u32 };
     Some(SmallTbl { tbl, vars: [vi, 0, 0, 0, 0], arity: 1 })
   } else if n.is_fun() {

--- a/src/tbl.rs
+++ b/src/tbl.rs
@@ -106,15 +106,15 @@ fn expand_table(tbl: u32, src_vars: &[u32], dst_vars: &[u32]) -> u32 {
   let mut len = 0u8;
   let (mut ia, mut ib) = (0, 0);
   while ia < va.len() && ib < vb.len() {
-    if len >= 5 && va[ia] != vb[ib] { return None; }
+    if len >= 5 { return None; }
     if va[ia] < vb[ib] { out[len as usize] = va[ia]; ia += 1; }
     else if va[ia] > vb[ib] { out[len as usize] = vb[ib]; ib += 1; }
     else { out[len as usize] = va[ia]; ia += 1; ib += 1; }
     len += 1;
   }
-  while ia < va.len() { if len > 5 { return None; } out[len as usize] = va[ia]; ia += 1; len += 1; }
-  while ib < vb.len() { if len > 5 { return None; } out[len as usize] = vb[ib]; ib += 1; len += 1; }
-  if len > 5 { None } else { Some((out, len)) }
+  while ia < va.len() { if len >= 5 { return None; } out[len as usize] = va[ia]; ia += 1; len += 1; }
+  while ib < vb.len() { if len >= 5 { return None; } out[len as usize] = vb[ib]; ib += 1; len += 1; }
+  Some((out, len))
 }
 
 /// Align two SmallTbls to a common variable set.

--- a/src/vhl_swarm.rs
+++ b/src/vhl_swarm.rs
@@ -180,6 +180,16 @@ impl<J,H> VhlSwarm<J,H> where J:JobKey, H:VhlJobHandler<J,W=VhlWorker<J,H>> {
 
   pub fn tup(&self, n:NID)->(NID,NID) { self.state.tup(n) }
 
+  /// Check the computed cache for a previously solved job.
+  /// This allows callers to avoid the swarm dispatch overhead on cache hits.
+  pub fn get_done(&self, job:&J)->Option<NID> { self.state.get_done(job) }
+
+  /// Store a computed result in the cache.
+  pub fn put_done(&self, job:J, nid:NID) { self.state.put_done(job, nid) }
+
+  /// Get or create a BDD node for the given (variable, hi, lo) triple.
+  pub fn vhl_to_nid(&self, v:VID, hi:NID, lo:NID)->NID { self.state.vhl_to_nid(v, hi, lo) }
+
   pub fn len(&self)->usize { self.state.len() }
   #[must_use] pub fn is_empty(&self) -> bool { self.len() == 0 }
 

--- a/src/wip.rs
+++ b/src/wip.rs
@@ -197,6 +197,11 @@ impl<K:Eq+Hash+Debug+Copy,P:Parts,B:WipBase<K,P>> WorkState<K,P,B> {
           Some(*v)}}}
     else { None }}
 
+  /// Store a completed result directly in the cache.
+  pub fn put_done(&self, k:K, nid:NID) {
+    self.cache.insert(k, Work::Done(nid));
+  }
+
   pub fn resolve_job(&self, q:&K, nid:NID)->WorkResult<K> {
     let mut ideps = vec![];
     {


### PR DESCRIPTION
## Summary

Landing the bex-side changes that unblock [bex#13](https://github.com/tangentstorm/bex/issues/13) (C++ wrapper for the [`bdd-benchmark`](https://github.com/SSoelvsten/bdd-benchmark) integration). The companion changes live on the same-named branch in [`tangentforks/bdd-benchmark`](https://github.com/tangentforks/bdd-benchmark/tree/claude/bdd-benchmark-integration-LfsoI).

### New features
- **Direct single-threaded ITE path on `BddBase`.** Opt in with
  `BddBase::set_direct_ite(true)` (or `bex_bdd_set_direct_ite(bdd, true)` from C) to
  bypass the swarm and recurse directly with a local `FxHashMap` computed table.
  Default is unchanged &mdash; the swarm is still used by everything that doesn't opt in.
  - Queens N=8 in `bdd-benchmark`: timed out &gt;30s &rarr; ~580 ms. Unblocks tic-tac-toe, hamiltonian, and game-of-life too.
- `VhlSwarm` now exposes `get_done` / `put_done` / `vhl_to_nid` so `BddBase::ite` can consult the shared computed cache before dispatching jobs, and `ite_direct` can build nodes without round-tripping through the swarm.
- New FFI `bex_swap_copy_to_bdd(swap, bdd, n)` so C callers can transfer a
  swap-solver result into a separate `BddBase` and use the normal
  `bex_bdd_node_count` / `bex_bdd_solution_count` on it.

### Bug fixes
- `tbl::merge_small` wrote past the end of a 5-element array before returning
  `None` on 6-variable ITEs, causing panics in the truth-table fast path. The
  `len > 5` guards are now `len >= 5`.
- `tbl::nid_to_small` accepted real-variable NIDs with an index &ge; `MAX_VAR`
  and fed them into the combinatorial encoder, which panicked with an array
  bounds error. Now it returns `None` so the caller falls back to the regular
  BDD path. This unblocked the `bdd-benchmark` hamiltonian workload (&gt;110 vars).

### Known issue surfaced during this work
- `SwapSolver::subst` panics when `Ops::RPN` contains repeated VIDs: [#30](https://github.com/tangentstorm/bex/issues/30). Not fixed here; reproduced by `BEX_MODE=swap ./bex_tic-tac-toe_bdd -n 10`.

## Commits (after rebase onto main)

- `1bf6f2f` perf: add direct recursive ITE with fast FxHashMap cache
- `5f52614` bdd: make direct-ITE opt-in via set_direct_ite()
- `8193398` tbl: guard nid_to_small against variables &gt;= MAX_VAR
- `d32ba5f` tbl+ffi: fix merge_small bounds bug; add swap_copy_to_bdd
- `343c0b0` changelog: add direct-ITE path, swap_copy_to_bdd, tbl fixes

## Test plan

- [x] `cargo test` &mdash; all 179 tests pass (includes main's new ZDD tests)
- [x] `cargo build --all-targets --tests --examples` &mdash; zero warnings
- [x] C++ adapter compiles without warnings
- [x] Correctness verified end-to-end against cudd/buddy on queens, tic-tac-toe, game-of-life, hamiltonian (results match the benchmark's hardcoded expected values)
- [x] Compared head-to-head; see the comment on bex#13 for the results table.

https://claude.ai/code/session_01FKuS1UEHjbDdhRpdjoCyhr